### PR TITLE
Change load() as a static method for GA

### DIFF
--- a/pygad.py
+++ b/pygad.py
@@ -602,7 +602,8 @@ class GA:
         with open(filename + ".pkl", 'wb') as file:
             pickle.dump(self, file)
 
-def load(filename):
+    @staticmethod
+    def load(filename):
     """
     Reading a saved instance of the genetic algorithm:
         -filename: Name of the file to read the instance. It must have no extension.


### PR DESCRIPTION
By putting `load()` as a static function for `GA`, the usage of this nice library could be more concise

```Python
from pygad import GA

def fitness_func(solution):
    return fitness_value

ga = GA(
    # ...
)

ga.run()
ga.plot_result()
best_solution, best_solution_fitness = ga.best_solution()
print(f'Best solution:, {best_solution}')
print(f'Fitness value of the best solution: {best_solution_fitness}')
ga.save(filename)
```