### PR TITLE
[PR] add args parameter for GA class

### DIFF
--- a/example.py
+++ b/example.py
@@ -8,13 +8,18 @@ Given the following function:
 What are the best values for the 6 weights (w1 to w6)? We are going to use the genetic algorithm to optimize this function.
 """
 
-function_inputs = [4,-2,3.5,5,-11,-4.7] # Function inputs.
-desired_output = 44 # Function output.
 
-def fitness_func(solution, solution_idx):
+def fitness_func(solution, solution_idx, args):
+    # additional function inputs are given by args
+    function_inputs = args[0]
+    desired_output = args[1]
     output = numpy.sum(solution*function_inputs)
     fitness = 1.0 / (numpy.abs(output - desired_output) + 0.000001)
     return fitness
+
+
+function_inputs = [4,-2,3.5,5,-11,-4.7] # Function inputs.
+desired_output = 44 # Function output.
 
 num_generations = 100 # Number of generations.
 num_parents_mating = 10 # Number of solutions to be selected as parents in the mating pool.
@@ -30,11 +35,13 @@ def on_generation(ga_instance):
     print("Change     = {change}".format(change=ga_instance.best_solution(pop_fitness=ga_instance.last_generation_fitness)[1] - last_fitness))
     last_fitness = ga_instance.best_solution(pop_fitness=ga_instance.last_generation_fitness)[1]
 
+
 ga_instance = pygad.GA(num_generations=num_generations,
                        num_parents_mating=num_parents_mating,
                        sol_per_pop=sol_per_pop,
                        num_genes=num_genes,
                        fitness_func=fitness_func,
+                       args=(function_inputs, desired_output),
                        on_generation=on_generation)
 
 # Running the GA to optimize the parameters of the function.

--- a/pygad.py
+++ b/pygad.py
@@ -15,6 +15,7 @@ class GA:
                  num_generations, 
                  num_parents_mating, 
                  fitness_func,
+                 args=None,
                  initial_population=None,
                  sol_per_pop=None, 
                  num_genes=None,
@@ -55,7 +56,8 @@ class GA:
         num_generations: Number of generations.
         num_parents_mating: Number of solutions to be selected as parents in the mating pool.
 
-        fitness_func: Accepts a function that must accept 2 parameters (a single solution and its index in the population) and return the fitness value of the solution. Available starting from PyGAD 1.0.17 until 1.0.20 with a single parameter representing the solution. Changed in PyGAD 2.0.0 and higher to include the second parameter representing the solution index.
+        fitness_func: Accepts a function that must accept more than 1 parameters (a single solution, its index in the population and parameters) and return the fitness value of the solution. Available starting from PyGAD 1.0.17 until 1.0.20 with a single parameter representing the solution. Changed in PyGAD 2.0.0 and higher to include the second parameter representing the solution index.
+        args: Accepts fixed parameters to be used in the fitness function
 
         initial_population: A user-defined initial population. It is useful when the user wants to start the generations with a custom initial population. It defaults to None which means no initial population is specified by the user. In this case, PyGAD creates an initial population using the 'sol_per_pop' and 'num_genes' parameters. An exception is raised if the 'initial_population' is None while any of the 2 parameters ('sol_per_pop' or 'num_genes') is also None.
         sol_per_pop: Number of solutions in the population. 
@@ -630,15 +632,17 @@ class GA:
 
         # Check if the fitness_func is a function.
         if callable(fitness_func):
-            # Check if the fitness function accepts 2 paramaters.
-            if (fitness_func.__code__.co_argcount == 2):
+            # Check if the fitness function accepts more than one paramater.
+            if (fitness_func.__code__.co_argcount >= 2):
                 self.fitness_func = fitness_func
             else:
                 self.valid_parameters = False
-                raise ValueError("The fitness function must accept 2 parameters:\n1) A solution to calculate its fitness value.\n2) The solution's index within the population.\n\nThe passed fitness function named '{funcname}' accepts {argcount} parameter(s).".format(funcname=fitness_func.__code__.co_name, argcount=fitness_func.__code__.co_argcount))
+                raise ValueError("The fitness function must accept more than one parameter:\n1) A solution to calculate its fitness value.\n2) The solution's index within the population.3) (optional) parameters\n\nThe passed fitness function named '{funcname}' accepts {argcount} parameter(s).".format(funcname=fitness_func.__code__.co_name, argcount=fitness_func.__code__.co_argcount))
         else:
             self.valid_parameters = False
             raise ValueError("The value assigned to the fitness_func parameter is expected to be of type function but ({fitness_func_type}) found.".format(fitness_func_type=type(fitness_func)))
+
+        self.args = args
 
         # Check if the on_start exists.
         if not (on_start is None):
@@ -1155,7 +1159,7 @@ class GA:
                 # Use the parent's index to return its pre-calculated fitness value.
                 fitness = self.last_generation_fitness[parent_idx]
             else:
-                fitness = self.fitness_func(sol, sol_idx)
+                fitness = self.fitness_func(sol, sol_idx, self.args)
             pop_fitness.append(fitness)
 
         pop_fitness = numpy.array(pop_fitness)

--- a/pygad.py
+++ b/pygad.py
@@ -2105,7 +2105,7 @@ class GA:
         fitness[:self.last_generation_parents.shape[0]] = self.last_generation_fitness[self.last_generation_parents_indices]
 
         for idx in range(len(parents_to_keep), fitness.shape[0]):
-            fitness[idx] = self.fitness_func(temp_population[idx], None)
+            fitness[idx] = self.fitness_func(temp_population[idx], None, self.args)
         average_fitness = numpy.mean(fitness)
 
         return average_fitness, fitness[len(parents_to_keep):]


### PR DESCRIPTION
# Related Issue #
#71 

# Description #
- Previously, `fitness_func` takes only two arguments: solution and solution index. If extra parameters are required for the `fitness_func`, we are forced to use global parameters as shown in 'example.py', which is inconvenient.
- Like [scipy.optimize.differential_evolution](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.differential_evolution.html), a new parameter, `args`, is added to `GA class`.
- **Tuple** `args` is passed to `fitness_func` so it can use fixed parameters.
=> `fitness_func(solution, solution_idx, args)`