### PR TITLE
Method callbacks for on_function and crossover/mutation set to None

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>GeneticAlgorithmPython</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.python.pydev.PyDevBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.python.pydev.pythonNature</nature>
+	</natures>
+</projectDescription>

--- a/.pydevproject
+++ b/.pydevproject
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?eclipse-pydev version="1.0"?><pydev_project>
+    <pydev_property name="org.python.pydev.PYTHON_PROJECT_INTERPRETER">Default</pydev_property>
+    <pydev_property name="org.python.pydev.PYTHON_PROJECT_VERSION">python interpreter</pydev_property>
+</pydev_project>

--- a/pygad.py
+++ b/pygad.py
@@ -11,6 +11,9 @@ Objective 1: Allow methods as callbacks while retaining compatibility with funct
 Objective 2: Allow for on_crossover and on_mutate callbacks even when crossover and mutate types are None.
     1. The on_crossover call is moved outside of the if-else check for crossover type is None. 
     2. The on_mutate call is moved outside of the if-else check for mutate type is None. 
+
+Change log:
+20221205 - Line 788 change on_fitness to on_parents.
 '''
 
 #barloff: inspect for isfunction vs. ismethod
@@ -785,7 +788,7 @@ class GA:
 				#barloff: check is method
                 elif inspect.ismethod(on_parents):
                     #barloff: Check as method accepts 3 paramaters to include caller's "self" reference.
-                    if (on_fitness.__code__.co_argcount == 3):
+                    if (on_parents.__code__.co_argcount == 3):
                         self.on_parents = on_parents
                         self.is_on_parents = 'method'
                     else:


### PR DESCRIPTION
The modifications to pygad are annotated as "#barloff" for easy search. The modifications:
(1) Allow to pass the user's Class instance reference for persistence flow of computations
(2) The user Class instance reference is now an optional parameter (cls_inst) provisioned to GA class constructor
(3) The on_crossover and on_mutation references now are always executed, even when crossover_type and mutation_type are None.
Now, when the fitness function or a on_<function> (e.g., on_parents) callback is made, the user is passed a reference to its own class instance. The implementation has access to its own attributes from within the callbacks.