### PR TITLE
Fix check for undefined pop fitness when using parallel processing

### DIFF
--- a/pygad/pygad.py
+++ b/pygad/pygad.py
@@ -1646,7 +1646,9 @@ class GA(utils.parent_selection.ParentSelection,
                 last_generation_elitism_as_list = [
                     list(gen_elitism) for gen_elitism in self.last_generation_elitism]
 
-            pop_fitness = ["undefined"] * len(self.population)
+            undefined_pop_fitness = object()
+
+            pop_fitness = [undefined_pop_fitness] * len(self.population)
             if self.parallel_processing is None:
                 # Calculating the fitness value of each solution in the current population.
                 for sol_idx, sol in enumerate(self.population):
@@ -1708,8 +1710,12 @@ class GA(utils.parent_selection.ParentSelection,
                     # Reaching this block means that batch fitness calculation is used.
 
                     # Indices of the solutions to calculate their fitness.
-                    solutions_indices = numpy.where(
-                        numpy.array(pop_fitness) == "undefined")[0]
+                    solutions_indices = numpy.array([
+                        sol_idx
+                        for (sol_idx, fitness)
+                        in enumerate(pop_fitness)
+                        if fitness is undefined_pop_fitness
+                    ])
                     # Number of batches.
                     num_batches = int(numpy.ceil(len(solutions_indices) / self.fitness_batch_size))
                     # For each batch, get its indices and call the fitness function.
@@ -1787,7 +1793,7 @@ class GA(utils.parent_selection.ParentSelection,
                     solutions_to_submit = []
                     for sol_idx, sol in enumerate(self.population):
                         # The "undefined" value means that the fitness of this solution must be calculated.
-                        if pop_fitness[sol_idx] == "undefined":
+                        if pop_fitness[sol_idx] is undefined_pop_fitness:
                             solutions_to_submit.append(sol.copy())
                             solutions_to_submit_indices.append(sol_idx)
 


### PR DESCRIPTION
When using parallel processing and multiple objectives are returned from the fitness function, then the following exception will be raised. This PR fixes the issue by avoiding comparisons between the `undefined` string and a numpy array. This would fix #236.

```
ERROR: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
Traceback (most recent call last):
  File ".venv/lib/python3.10/site-packages/pygad/pygad.py", line 1790, in cal_pop_fitness
    if pop_fitness[sol_idx] == "undefined":
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

Version information:
```
$ python
Python 3.10.12 (main, Jun 11 2023, 05:26:28) [GCC 11.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import pygad
>>> pygad.__version__
'3.2.0'
```