### PR TITLE
Fixing typos in logging + docs

### DIFF
--- a/docs/source/pygad_more.rst
+++ b/docs/source/pygad_more.rst
@@ -595,7 +595,7 @@ After running the code again, it will find the same result.
    [ 2.77249188 -4.06570662  0.04196872 -3.47770796 -0.57502138 -3.22775267]
    0.04872203136549972
 
-Continue without Loosing Progress
+Continue without Losing Progress
 =================================
 
 In `PyGAD
@@ -615,7 +615,7 @@ call to the ``run()`` method.
 4. ``self.solutions_fitness``
 
 This helps the user to continue where the last run stopped without
-loosing the values of these 4 attributes.
+losing the values of these 4 attributes.
 
 Now, the user can save the model by calling the ``save()`` method.
 

--- a/docs/source/releases.rst
+++ b/docs/source/releases.rst
@@ -1020,8 +1020,8 @@ Release Date: 9 September 2022
    generation. Another advantage happens when the instance is loaded and
    the ``run()`` method is called, as the old fitness value are shown on
    the graph alongside with the new fitness values. Read more in this
-   section: `Continue without Loosing
-   Progress <https://pygad.readthedocs.io/en/latest/pygad_more.html#continue-without-loosing-progress>`__
+   section: `Continue without Losing
+   Progress <https://pygad.readthedocs.io/en/latest/pygad_more.html#continue-without-losing-progress>`__
 
 4. Thanks `Prof. Fernando Jiménez
    Barrionuevo <http://webs.um.es/fernan>`__ (Dept. of Information and

--- a/pygad/pygad.py
+++ b/pygad/pygad.py
@@ -726,7 +726,7 @@ class GA(utils.parent_selection.ParentSelection,
                                 if self.mutation_probability is None:
                                     if not self.suppress_warnings:
                                         warnings.warn(
-                                            f"The percentage of genes to mutate (mutation_percent_genes={mutation_percent_genes}) resutled in selecting ({mutation_num_genes}) genes. The number of genes to mutate is set to 1 (mutation_num_genes=1).\nIf you do not want to mutate any gene, please set mutation_type=None.")
+                                            f"The percentage of genes to mutate (mutation_percent_genes={mutation_percent_genes}) resulted in selecting ({mutation_num_genes}) genes. The number of genes to mutate is set to 1 (mutation_num_genes=1).\nIf you do not want to mutate any gene, please set mutation_type=None.")
                                 mutation_num_genes = 1
 
                         elif type(mutation_percent_genes) in GA.supported_int_float_types:
@@ -745,7 +745,7 @@ class GA(utils.parent_selection.ParentSelection,
                                 if mutation_num_genes == 0:
                                     if self.mutation_probability is None:
                                         if not self.suppress_warnings:
-                                            warnings.warn(f"The percentage of genes to mutate (mutation_percent_genes={mutation_percent_genes}) resutled in selecting ({mutation_num_genes}) genes. The number of genes to mutate is set to 1 (mutation_num_genes=1).\nIf you do not want to mutate any gene, please set mutation_type=None.")
+                                            warnings.warn(f"The percentage of genes to mutate (mutation_percent_genes={mutation_percent_genes}) resulted in selecting ({mutation_num_genes}) genes. The number of genes to mutate is set to 1 (mutation_num_genes=1).\nIf you do not want to mutate any gene, please set mutation_type=None.")
                                     mutation_num_genes = 1
                         else:
                             self.valid_parameters = False
@@ -771,7 +771,7 @@ class GA(utils.parent_selection.ParentSelection,
                                     # Based on the mutation percentage of genes, if the number of selected genes for mutation is less than the least possible value which is 1, then the number will be set to 1.
                                     if mutation_num_genes[idx] == 0:
                                         if not self.suppress_warnings:
-                                            warnings.warn(f"The percentage of genes to mutate ({mutation_percent_genes[idx]}) resutled in selecting ({mutation_num_genes[idx]}) genes. The number of genes to mutate is set to 1 (mutation_num_genes=1).\nIf you do not want to mutate any gene, please set mutation_type=None.")
+                                            warnings.warn(f"The percentage of genes to mutate ({mutation_percent_genes[idx]}) resulted in selecting ({mutation_num_genes[idx]}) genes. The number of genes to mutate is set to 1 (mutation_num_genes=1).\nIf you do not want to mutate any gene, please set mutation_type=None.")
                                         mutation_num_genes[idx] = 1
                                 if mutation_percent_genes[0] < mutation_percent_genes[1]:
                                     if not self.suppress_warnings:


### PR DESCRIPTION
Fixing a couple typos found when using this library. 

loosing -> losing
resutled -> resulted