### PR TITLE
Improvement on memory usage

### DIFF
--- a/examples/KerasGA/image_classification_CNN.py
+++ b/examples/KerasGA/image_classification_CNN.py
@@ -2,6 +2,8 @@ import tensorflow.keras
 import pygad.kerasga
 import numpy
 import pygad
+import gc
+
 
 def fitness_func(ga_instanse, solution, sol_idx):
     global data_inputs, data_outputs, keras_ga, model
@@ -11,27 +13,33 @@ def fitness_func(ga_instanse, solution, sol_idx):
                                         data=data_inputs)
 
     cce = tensorflow.keras.losses.CategoricalCrossentropy()
-    solution_fitness = 1.0 / (cce(data_outputs, predictions).numpy() + 0.00000001)
+    solution_fitness = 1.0 / \
+        (cce(data_outputs, predictions).numpy() + 0.00000001)
 
     return solution_fitness
+
 
 def on_generation(ga_instance):
     print(f"Generation = {ga_instance.generations_completed}")
     print(f"Fitness    = {ga_instance.best_solution()[1]}")
+    gc.collect()  # can useful for not exploding the memory usage on notebooks (ipynb) freeing memory
+
 
 # Build the keras model using the functional API.
 input_layer = tensorflow.keras.layers.Input(shape=(100, 100, 3))
 conv_layer1 = tensorflow.keras.layers.Conv2D(filters=5,
                                              kernel_size=7,
                                              activation="relu")(input_layer)
-max_pool1 = tensorflow.keras.layers.MaxPooling2D(pool_size=(5,5),
+max_pool1 = tensorflow.keras.layers.MaxPooling2D(pool_size=(5, 5),
                                                  strides=5)(conv_layer1)
 conv_layer2 = tensorflow.keras.layers.Conv2D(filters=3,
                                              kernel_size=3,
                                              activation="relu")(max_pool1)
-flatten_layer  = tensorflow.keras.layers.Flatten()(conv_layer2)
-dense_layer = tensorflow.keras.layers.Dense(15, activation="relu")(flatten_layer)
-output_layer = tensorflow.keras.layers.Dense(4, activation="softmax")(dense_layer)
+flatten_layer = tensorflow.keras.layers.Flatten()(conv_layer2)
+dense_layer = tensorflow.keras.layers.Dense(
+    15, activation="relu")(flatten_layer)
+output_layer = tensorflow.keras.layers.Dense(
+    4, activation="softmax")(dense_layer)
 
 model = tensorflow.keras.Model(inputs=input_layer, outputs=output_layer)
 
@@ -47,13 +55,15 @@ data_outputs = numpy.load("../data/dataset_outputs.npy")
 data_outputs = tensorflow.keras.utils.to_categorical(data_outputs)
 
 # Prepare the PyGAD parameters. Check the documentation for more information: https://pygad.readthedocs.io/en/latest/README_pygad_ReadTheDocs.html#pygad-ga-class
-num_generations = 200 # Number of generations.
-num_parents_mating = 5 # Number of solutions to be selected as parents in the mating pool.
-initial_population = keras_ga.population_weights # Initial population of network weights.
+num_generations = 200  # Number of generations.
+# Number of solutions to be selected as parents in the mating pool.
+num_parents_mating = 5
+# Initial population of network weights.
+initial_population = keras_ga.population_weights
 
 # Create an instance of the pygad.GA class
-ga_instance = pygad.GA(num_generations=num_generations, 
-                       num_parents_mating=num_parents_mating, 
+ga_instance = pygad.GA(num_generations=num_generations,
+                       num_parents_mating=num_parents_mating,
                        initial_population=initial_population,
                        fitness_func=fitness_func,
                        on_generation=on_generation)
@@ -62,7 +72,8 @@ ga_instance = pygad.GA(num_generations=num_generations,
 ga_instance.run()
 
 # After the generations complete, some plots are showed that summarize how the outputs/fitness values evolve over generations.
-ga_instance.plot_fitness(title="PyGAD & Keras - Iteration vs. Fitness", linewidth=4)
+ga_instance.plot_fitness(
+    title="PyGAD & Keras - Iteration vs. Fitness", linewidth=4)
 
 # Returning the details of the best solution.
 solution, solution_fitness, solution_idx = ga_instance.best_solution()


### PR DESCRIPTION
I find the use of garbage collector usefull when using the pygad on colab, because when I tried to train some examples on standard version of quotas colab (12GB RAM), not PRO, the usage of memory exceeded the quantity available and so the colab restarted itself not allowing to train for more than 3 generations. With `gc.collect()` used outside of `on_generation ` of inside was possible to release the memory and not crash.