### PR TITLE
Fix a typo in example_custom_operators

### DIFF
--- a/examples/example_custom_operators.py
+++ b/examples/example_custom_operators.py
@@ -41,7 +41,7 @@ def crossover_func(parents, offspring_size, ga_instance):
         parent1 = parents[idx % parents.shape[0], :].copy()
         parent2 = parents[(idx + 1) % parents.shape[0], :].copy()
 
-        random_split_point = numpy.random.choice(range(offspring_size[0]))
+        random_split_point = numpy.random.choice(range(offspring_size[1]))
 
         parent1[random_split_point:] = parent2[random_split_point:]
 


### PR DESCRIPTION
In the crossover function, the split point is chosen in the range of the offspring size, instead of the solution size.

An out-of-range split point is silently ignored by the range selection: it selects all genes from parent1, and none from parent2. However, the error can be demonstrated by throwing an exception if the split point is out of range.