### PR TITLE
PyGAD 3.4.0

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,11 +18,11 @@
 # -- Project information -----------------------------------------------------
 
 project = 'PyGAD'
-copyright = '2024, Ahmed Fawzy Gad'
+copyright = '2025, Ahmed Fawzy Gad'
 author = 'Ahmed Fawzy Gad'
 
 # The full version, including alpha/beta/rc tags
-release = '3.3.1'
+release = '3.4.0'
 
 master_doc = 'index'
 

--- a/docs/source/pygad.rst
+++ b/docs/source/pygad.rst
@@ -29,401 +29,391 @@ algorithm to different types of applications.
 
 The ``pygad.GA`` class constructor supports the following parameters:
 
--  ``num_generations``: Number of generations.
+- ``num_generations``: Number of generations.
 
--  ``num_parents_mating``: Number of solutions to be selected as
-   parents.
+- ``num_parents_mating``: Number of solutions to be selected as parents.
 
--  ``fitness_func``: Accepts a function/method and returns the fitness
-   value(s) of the solution. If a function is passed, then it must
-   accept 3 parameters (1. the instance of the ``pygad.GA`` class, 2. a
-   single solution, and 3. its index in the population). If method, then
-   it accepts a fourth parameter representing the method's class
-   instance. Check the `Preparing the fitness_func
-   Parameter <https://pygad.readthedocs.io/en/latest/pygad.html#preparing-the-fitness-func-parameter>`__
-   section for information about creating such a function. In `PyGAD
-   3.2.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-3-2-0>`__,
-   multi-objective optimization is supported. To consider the problem as
-   multi-objective, just return a ``list``, ``tuple``, or
-   ``numpy.ndarray`` from the fitness function.
+- ``fitness_func``: Accepts a function/method and returns the fitness
+  value(s) of the solution. If a function is passed, then it must accept
+  3 parameters (1. the instance of the ``pygad.GA`` class, 2. a single
+  solution, and 3. its index in the population). If method, then it
+  accepts a fourth parameter representing the method's class instance.
+  Check the `Preparing the fitness_func
+  Parameter <https://pygad.readthedocs.io/en/latest/pygad.html#preparing-the-fitness-func-parameter>`__
+  section for information about creating such a function. In `PyGAD
+  3.2.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-3-2-0>`__,
+  multi-objective optimization is supported. To consider the problem as
+  multi-objective, just return a ``list``, ``tuple``, or
+  ``numpy.ndarray`` from the fitness function.
 
--  ``fitness_batch_size=None``: A new optional parameter called
-   ``fitness_batch_size`` is supported to calculate the fitness function
-   in batches. If it is assigned the value ``1`` or ``None`` (default),
-   then the normal flow is used where the fitness function is called for
-   each individual solution. If the ``fitness_batch_size`` parameter is
-   assigned a value satisfying this condition
-   ``1 < fitness_batch_size <= sol_per_pop``, then the solutions are
-   grouped into batches of size ``fitness_batch_size`` and the fitness
-   function is called once for each batch. Check the `Batch Fitness
-   Calculation <https://pygad.readthedocs.io/en/latest/pygad_more.html#batch-fitness-calculation>`__
-   section for more details and examples. Added in from `PyGAD
-   2.19.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-19-0>`__.
+- ``fitness_batch_size=None``: A new optional parameter called
+  ``fitness_batch_size`` is supported to calculate the fitness function
+  in batches. If it is assigned the value ``1`` or ``None`` (default),
+  then the normal flow is used where the fitness function is called for
+  each individual solution. If the ``fitness_batch_size`` parameter is
+  assigned a value satisfying this condition
+  ``1 < fitness_batch_size <= sol_per_pop``, then the solutions are
+  grouped into batches of size ``fitness_batch_size`` and the fitness
+  function is called once for each batch. Check the `Batch Fitness
+  Calculation <https://pygad.readthedocs.io/en/latest/pygad_more.html#batch-fitness-calculation>`__
+  section for more details and examples. Added in from `PyGAD
+  2.19.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-19-0>`__.
 
--  ``initial_population``: A user-defined initial population. It is
-   useful when the user wants to start the generations with a custom
-   initial population. It defaults to ``None`` which means no initial
-   population is specified by the user. In this case,
-   `PyGAD <https://pypi.org/project/pygad>`__ creates an initial
-   population using the ``sol_per_pop`` and ``num_genes`` parameters. An
-   exception is raised if the ``initial_population`` is ``None`` while
-   any of the 2 parameters (``sol_per_pop`` or ``num_genes``) is also
-   ``None``. Introduced in `PyGAD
-   2.0.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-0-0>`__
-   and higher.
+- ``initial_population``: A user-defined initial population. It is
+  useful when the user wants to start the generations with a custom
+  initial population. It defaults to ``None`` which means no initial
+  population is specified by the user. In this case,
+  `PyGAD <https://pypi.org/project/pygad>`__ creates an initial
+  population using the ``sol_per_pop`` and ``num_genes`` parameters. An
+  exception is raised if the ``initial_population`` is ``None`` while
+  any of the 2 parameters (``sol_per_pop`` or ``num_genes``) is also
+  ``None``. Introduced in `PyGAD
+  2.0.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-0-0>`__
+  and higher.
 
--  ``sol_per_pop``: Number of solutions (i.e. chromosomes) within the
-   population. This parameter has no action if ``initial_population``
-   parameter exists.
+- ``sol_per_pop``: Number of solutions (i.e. chromosomes) within the
+  population. This parameter has no action if ``initial_population``
+  parameter exists.
 
--  ``num_genes``: Number of genes in the solution/chromosome. This
-   parameter is not needed if the user feeds the initial population to
-   the ``initial_population`` parameter.
+- ``num_genes``: Number of genes in the solution/chromosome. This
+  parameter is not needed if the user feeds the initial population to
+  the ``initial_population`` parameter.
 
--  ``gene_type=float``: Controls the gene type. It can be assigned to a
-   single data type that is applied to all genes or can specify the data
-   type of each individual gene. It defaults to ``float`` which means
-   all genes are of ``float`` data type. Starting from `PyGAD
-   2.9.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-9-0>`__,
-   the ``gene_type`` parameter can be assigned to a numeric value of any
-   of these types: ``int``, ``float``, and
-   ``numpy.int/uint/float(8-64)``. Starting from `PyGAD
-   2.14.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-14-0>`__,
-   it can be assigned to a ``list``, ``tuple``, or a ``numpy.ndarray``
-   which hold a data type for each gene (e.g.
-   ``gene_type=[int, float, numpy.int8]``). This helps to control the
-   data type of each individual gene. In `PyGAD
-   2.15.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-15-0>`__,
-   a precision for the ``float`` data types can be specified (e.g.
-   ``gene_type=[float, 2]``.
+- ``gene_type=float``: Controls the gene type. It can be assigned to a
+  single data type that is applied to all genes or can specify the data
+  type of each individual gene. It defaults to ``float`` which means all
+  genes are of ``float`` data type. Starting from `PyGAD
+  2.9.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-9-0>`__,
+  the ``gene_type`` parameter can be assigned to a numeric value of any
+  of these types: ``int``, ``float``, and
+  ``numpy.int/uint/float(8-64)``. Starting from `PyGAD
+  2.14.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-14-0>`__,
+  it can be assigned to a ``list``, ``tuple``, or a ``numpy.ndarray``
+  which hold a data type for each gene (e.g.
+  ``gene_type=[int, float, numpy.int8]``). This helps to control the
+  data type of each individual gene. In `PyGAD
+  2.15.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-15-0>`__,
+  a precision for the ``float`` data types can be specified (e.g.
+  ``gene_type=[float, 2]``.
 
--  ``init_range_low=-4``: The lower value of the random range from which
-   the gene values in the initial population are selected.
-   ``init_range_low`` defaults to ``-4``. Available in `PyGAD
-   1.0.20 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-1-0-20>`__
-   and higher. This parameter has no action if the
-   ``initial_population`` parameter exists.
+- ``init_range_low=-4``: The lower value of the random range from which
+  the gene values in the initial population are selected.
+  ``init_range_low`` defaults to ``-4``. Available in `PyGAD
+  1.0.20 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-1-0-20>`__
+  and higher. This parameter has no action if the ``initial_population``
+  parameter exists.
 
--  ``init_range_high=4``: The upper value of the random range from which
-   the gene values in the initial population are selected.
-   ``init_range_high`` defaults to ``+4``. Available in `PyGAD
-   1.0.20 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-1-0-20>`__
-   and higher. This parameter has no action if the
-   ``initial_population`` parameter exists.
+- ``init_range_high=4``: The upper value of the random range from which
+  the gene values in the initial population are selected.
+  ``init_range_high`` defaults to ``+4``. Available in `PyGAD
+  1.0.20 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-1-0-20>`__
+  and higher. This parameter has no action if the ``initial_population``
+  parameter exists.
 
--  ``parent_selection_type="sss"``: The parent selection type. Supported
-   types are ``sss`` (for steady-state selection), ``rws`` (for roulette
-   wheel selection), ``sus`` (for stochastic universal selection),
-   ``rank`` (for rank selection), ``random`` (for random selection), and
-   ``tournament`` (for tournament selection). A custom parent selection
-   function can be passed starting from `PyGAD
-   2.16.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-16-0>`__.
-   Check the `User-Defined Crossover, Mutation, and Parent Selection
-   Operators <https://pygad.readthedocs.io/en/latest/utils.html#user-defined-crossover-mutation-and-parent-selection-operators>`__
-   section for more details about building a user-defined parent
-   selection function.
+- ``parent_selection_type="sss"``: The parent selection type. Supported
+  types are ``sss`` (for steady-state selection), ``rws`` (for roulette
+  wheel selection), ``sus`` (for stochastic universal selection),
+  ``rank`` (for rank selection), ``random`` (for random selection), and
+  ``tournament`` (for tournament selection). A custom parent selection
+  function can be passed starting from `PyGAD
+  2.16.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-16-0>`__.
+  Check the `User-Defined Crossover, Mutation, and Parent Selection
+  Operators <https://pygad.readthedocs.io/en/latest/utils.html#user-defined-crossover-mutation-and-parent-selection-operators>`__
+  section for more details about building a user-defined parent
+  selection function.
 
--  ``keep_parents=-1``: Number of parents to keep in the current
-   population. ``-1`` (default) means to keep all parents in the next
-   population. ``0`` means keep no parents in the next population. A
-   value ``greater than 0`` means keeps the specified number of parents
-   in the next population. Note that the value assigned to
-   ``keep_parents`` cannot be ``< - 1`` or greater than the number of
-   solutions within the population ``sol_per_pop``. Starting from `PyGAD
-   2.18.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-18-0>`__,
-   this parameter have an effect only when the ``keep_elitism``
-   parameter is ``0``. Starting from `PyGAD
-   2.20.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-20-0>`__,
-   the parents' fitness from the last generation will not be re-used if
-   ``keep_parents=0``.
+- ``keep_parents=-1``: Number of parents to keep in the current
+  population. ``-1`` (default) means to keep all parents in the next
+  population. ``0`` means keep no parents in the next population. A
+  value ``greater than 0`` means keeps the specified number of parents
+  in the next population. Note that the value assigned to
+  ``keep_parents`` cannot be ``< - 1`` or greater than the number of
+  solutions within the population ``sol_per_pop``. Starting from `PyGAD
+  2.18.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-18-0>`__,
+  this parameter have an effect only when the ``keep_elitism`` parameter
+  is ``0``. Starting from `PyGAD
+  2.20.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-20-0>`__,
+  the parents' fitness from the last generation will not be re-used if
+  ``keep_parents=0``.
 
--  ``keep_elitism=1``: Added in `PyGAD
-   2.18.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-18-0>`__.
-   It can take the value ``0`` or a positive integer that satisfies
-   (``0 <= keep_elitism <= sol_per_pop``). It defaults to ``1`` which
-   means only the best solution in the current generation is kept in the
-   next generation. If assigned ``0``, this means it has no effect. If
-   assigned a positive integer ``K``, then the best ``K`` solutions are
-   kept in the next generation. It cannot be assigned a value greater
-   than the value assigned to the ``sol_per_pop`` parameter. If this
-   parameter has a value different than ``0``, then the ``keep_parents``
-   parameter will have no effect.
+- ``keep_elitism=1``: Added in `PyGAD
+  2.18.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-18-0>`__.
+  It can take the value ``0`` or a positive integer that satisfies
+  (``0 <= keep_elitism <= sol_per_pop``). It defaults to ``1`` which
+  means only the best solution in the current generation is kept in the
+  next generation. If assigned ``0``, this means it has no effect. If
+  assigned a positive integer ``K``, then the best ``K`` solutions are
+  kept in the next generation. It cannot be assigned a value greater
+  than the value assigned to the ``sol_per_pop`` parameter. If this
+  parameter has a value different than ``0``, then the ``keep_parents``
+  parameter will have no effect.
 
--  ``K_tournament=3``: In case that the parent selection type is
-   ``tournament``, the ``K_tournament`` specifies the number of parents
-   participating in the tournament selection. It defaults to ``3``.
+- ``K_tournament=3``: In case that the parent selection type is
+  ``tournament``, the ``K_tournament`` specifies the number of parents
+  participating in the tournament selection. It defaults to ``3``.
 
--  ``crossover_type="single_point"``: Type of the crossover operation.
-   Supported types are ``single_point`` (for single-point crossover),
-   ``two_points`` (for two points crossover), ``uniform`` (for uniform
-   crossover), and ``scattered`` (for scattered crossover). Scattered
-   crossover is supported from PyGAD
-   `2.9.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-9-0>`__
-   and higher. It defaults to ``single_point``. A custom crossover
-   function can be passed starting from `PyGAD
-   2.16.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-16-0>`__.
-   Check the `User-Defined Crossover, Mutation, and Parent Selection
-   Operators <https://pygad.readthedocs.io/en/latest/pygad_more.html#user-defined-crossover-mutation-and-parent-selection-operators>`__
-   section for more details about creating a user-defined crossover
-   function. Starting from `PyGAD
-   2.2.2 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-2-2>`__
-   and higher, if ``crossover_type=None``, then the crossover step is
-   bypassed which means no crossover is applied and thus no offspring
-   will be created in the next generations. The next generation will use
-   the solutions in the current population.
+- ``crossover_type="single_point"``: Type of the crossover operation.
+  Supported types are ``single_point`` (for single-point crossover),
+  ``two_points`` (for two points crossover), ``uniform`` (for uniform
+  crossover), and ``scattered`` (for scattered crossover). Scattered
+  crossover is supported from PyGAD
+  `2.9.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-9-0>`__
+  and higher. It defaults to ``single_point``. A custom crossover
+  function can be passed starting from `PyGAD
+  2.16.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-16-0>`__.
+  Check the `User-Defined Crossover, Mutation, and Parent Selection
+  Operators <https://pygad.readthedocs.io/en/latest/pygad_more.html#user-defined-crossover-mutation-and-parent-selection-operators>`__
+  section for more details about creating a user-defined crossover
+  function. Starting from `PyGAD
+  2.2.2 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-2-2>`__
+  and higher, if ``crossover_type=None``, then the crossover step is
+  bypassed which means no crossover is applied and thus no offspring
+  will be created in the next generations. The next generation will use
+  the solutions in the current population.
 
--  ``crossover_probability=None``: The probability of selecting a parent
-   for applying the crossover operation. Its value must be between 0.0
-   and 1.0 inclusive. For each parent, a random value between 0.0 and
-   1.0 is generated. If this random value is less than or equal to the
-   value assigned to the ``crossover_probability`` parameter, then the
-   parent is selected. Added in `PyGAD
-   2.5.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-5-0>`__
-   and higher.
+- ``crossover_probability=None``: The probability of selecting a parent
+  for applying the crossover operation. Its value must be between 0.0
+  and 1.0 inclusive. For each parent, a random value between 0.0 and 1.0
+  is generated. If this random value is less than or equal to the value
+  assigned to the ``crossover_probability`` parameter, then the parent
+  is selected. Added in `PyGAD
+  2.5.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-5-0>`__
+  and higher.
 
--  ``mutation_type="random"``: Type of the mutation operation. Supported
-   types are ``random`` (for random mutation), ``swap`` (for swap
-   mutation), ``inversion`` (for inversion mutation), ``scramble`` (for
-   scramble mutation), and ``adaptive`` (for adaptive mutation). It
-   defaults to ``random``. A custom mutation function can be passed
-   starting from `PyGAD
-   2.16.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-16-0>`__.
-   Check the `User-Defined Crossover, Mutation, and Parent Selection
-   Operators <https://pygad.readthedocs.io/en/latest/pygad_more.html#user-defined-crossover-mutation-and-parent-selection-operators>`__
-   section for more details about creating a user-defined mutation
-   function. Starting from `PyGAD
-   2.2.2 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-2-2>`__
-   and higher, if ``mutation_type=None``, then the mutation step is
-   bypassed which means no mutation is applied and thus no changes are
-   applied to the offspring created using the crossover operation. The
-   offspring will be used unchanged in the next generation. ``Adaptive``
-   mutation is supported starting from `PyGAD
-   2.10.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-10-0>`__.
-   For more information about adaptive mutation, go the the `Adaptive
-   Mutation <https://pygad.readthedocs.io/en/latest/pygad_more.html#adaptive-mutation>`__
-   section. For example about using adaptive mutation, check the `Use
-   Adaptive Mutation in
-   PyGAD <https://pygad.readthedocs.io/en/latest/pygad_more.html#use-adaptive-mutation-in-pygad>`__
-   section.
+- ``mutation_type="random"``: Type of the mutation operation. Supported
+  types are ``random`` (for random mutation), ``swap`` (for swap
+  mutation), ``inversion`` (for inversion mutation), ``scramble`` (for
+  scramble mutation), and ``adaptive`` (for adaptive mutation). It
+  defaults to ``random``. A custom mutation function can be passed
+  starting from `PyGAD
+  2.16.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-16-0>`__.
+  Check the `User-Defined Crossover, Mutation, and Parent Selection
+  Operators <https://pygad.readthedocs.io/en/latest/pygad_more.html#user-defined-crossover-mutation-and-parent-selection-operators>`__
+  section for more details about creating a user-defined mutation
+  function. Starting from `PyGAD
+  2.2.2 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-2-2>`__
+  and higher, if ``mutation_type=None``, then the mutation step is
+  bypassed which means no mutation is applied and thus no changes are
+  applied to the offspring created using the crossover operation. The
+  offspring will be used unchanged in the next generation. ``Adaptive``
+  mutation is supported starting from `PyGAD
+  2.10.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-10-0>`__.
+  For more information about adaptive mutation, go the the `Adaptive
+  Mutation <https://pygad.readthedocs.io/en/latest/pygad_more.html#adaptive-mutation>`__
+  section. For example about using adaptive mutation, check the `Use
+  Adaptive Mutation in
+  PyGAD <https://pygad.readthedocs.io/en/latest/pygad_more.html#use-adaptive-mutation-in-pygad>`__
+  section.
 
--  ``mutation_probability=None``: The probability of selecting a gene
-   for applying the mutation operation. Its value must be between 0.0
-   and 1.0 inclusive. For each gene in a solution, a random value
-   between 0.0 and 1.0 is generated. If this random value is less than
-   or equal to the value assigned to the ``mutation_probability``
-   parameter, then the gene is selected. If this parameter exists, then
-   there is no need for the 2 parameters ``mutation_percent_genes`` and
-   ``mutation_num_genes``. Added in `PyGAD
-   2.5.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-5-0>`__
-   and higher.
+- ``mutation_probability=None``: The probability of selecting a gene for
+  applying the mutation operation. Its value must be between 0.0 and 1.0
+  inclusive. For each gene in a solution, a random value between 0.0 and
+  1.0 is generated. If this random value is less than or equal to the
+  value assigned to the ``mutation_probability`` parameter, then the
+  gene is selected. If this parameter exists, then there is no need for
+  the 2 parameters ``mutation_percent_genes`` and
+  ``mutation_num_genes``. Added in `PyGAD
+  2.5.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-5-0>`__
+  and higher.
 
--  ``mutation_by_replacement=False``: An optional bool parameter. It
-   works only when the selected type of mutation is random
-   (``mutation_type="random"``). In this case,
-   ``mutation_by_replacement=True`` means replace the gene by the
-   randomly generated value. If False, then it has no effect and random
-   mutation works by adding the random value to the gene. Supported in
-   `PyGAD
-   2.2.2 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-2-2>`__
-   and higher. Check the changes in `PyGAD
-   2.2.2 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-2-2>`__
-   under the Release History section for an example.
+- ``mutation_by_replacement=False``: An optional bool parameter. It
+  works only when the selected type of mutation is random
+  (``mutation_type="random"``). In this case,
+  ``mutation_by_replacement=True`` means replace the gene by the
+  randomly generated value. If False, then it has no effect and random
+  mutation works by adding the random value to the gene. Supported in
+  `PyGAD
+  2.2.2 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-2-2>`__
+  and higher. Check the changes in `PyGAD
+  2.2.2 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-2-2>`__
+  under the Release History section for an example.
 
--  ``mutation_percent_genes="default"``: Percentage of genes to mutate.
-   It defaults to the string ``"default"`` which is later translated
-   into the integer ``10`` which means 10% of the genes will be mutated.
-   It must be ``>0`` and ``<=100``. Out of this percentage, the number
-   of genes to mutate is deduced which is assigned to the
-   ``mutation_num_genes`` parameter. The ``mutation_percent_genes``
-   parameter has no action if ``mutation_probability`` or
-   ``mutation_num_genes`` exist. Starting from `PyGAD
-   2.2.2 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-2-2>`__
-   and higher, this parameter has no action if ``mutation_type`` is
-   ``None``.
+- ``mutation_percent_genes="default"``: Percentage of genes to mutate.
+  It defaults to the string ``"default"`` which is later translated into
+  the integer ``10`` which means 10% of the genes will be mutated. It
+  must be ``>0`` and ``<=100``. Out of this percentage, the number of
+  genes to mutate is deduced which is assigned to the
+  ``mutation_num_genes`` parameter. The ``mutation_percent_genes``
+  parameter has no action if ``mutation_probability`` or
+  ``mutation_num_genes`` exist. Starting from `PyGAD
+  2.2.2 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-2-2>`__
+  and higher, this parameter has no action if ``mutation_type`` is
+  ``None``.
 
--  ``mutation_num_genes=None``: Number of genes to mutate which defaults
-   to ``None`` meaning that no number is specified. The
-   ``mutation_num_genes`` parameter has no action if the parameter
-   ``mutation_probability`` exists. Starting from `PyGAD
-   2.2.2 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-2-2>`__
-   and higher, this parameter has no action if ``mutation_type`` is
-   ``None``.
+- ``mutation_num_genes=None``: Number of genes to mutate which defaults
+  to ``None`` meaning that no number is specified. The
+  ``mutation_num_genes`` parameter has no action if the parameter
+  ``mutation_probability`` exists. Starting from `PyGAD
+  2.2.2 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-2-2>`__
+  and higher, this parameter has no action if ``mutation_type`` is
+  ``None``.
 
--  ``random_mutation_min_val=-1.0``: For ``random`` mutation, the
-   ``random_mutation_min_val`` parameter specifies the start value of
-   the range from which a random value is selected to be added to the
-   gene. It defaults to ``-1``. Starting from `PyGAD
-   2.2.2 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-2-2>`__
-   and higher, this parameter has no action if ``mutation_type`` is
-   ``None``.
+- ``random_mutation_min_val=-1.0``: For ``random`` mutation, the
+  ``random_mutation_min_val`` parameter specifies the start value of the
+  range from which a random value is selected to be added to the gene.
+  It defaults to ``-1``. Starting from `PyGAD
+  2.2.2 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-2-2>`__
+  and higher, this parameter has no action if ``mutation_type`` is
+  ``None``.
 
--  ``random_mutation_max_val=1.0``: For ``random`` mutation, the
-   ``random_mutation_max_val`` parameter specifies the end value of the
-   range from which a random value is selected to be added to the gene.
-   It defaults to ``+1``. Starting from `PyGAD
-   2.2.2 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-2-2>`__
-   and higher, this parameter has no action if ``mutation_type`` is
-   ``None``.
+- ``random_mutation_max_val=1.0``: For ``random`` mutation, the
+  ``random_mutation_max_val`` parameter specifies the end value of the
+  range from which a random value is selected to be added to the gene.
+  It defaults to ``+1``. Starting from `PyGAD
+  2.2.2 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-2-2>`__
+  and higher, this parameter has no action if ``mutation_type`` is
+  ``None``.
 
--  ``gene_space=None``: It is used to specify the possible values for
-   each gene in case the user wants to restrict the gene values. It is
-   useful if the gene space is restricted to a certain range or to
-   discrete values. It accepts a ``list``, ``range``, or
-   ``numpy.ndarray``. When all genes have the same global space, specify
-   their values as a ``list``/``tuple``/``range``/``numpy.ndarray``. For
-   example, ``gene_space = [0.3, 5.2, -4, 8]`` restricts the gene values
-   to the 4 specified values. If each gene has its own space, then the
-   ``gene_space`` parameter can be nested like
-   ``[[0.4, -5], [0.5, -3.2, 8.2, -9], ...]`` where the first sublist
-   determines the values for the first gene, the second sublist for the
-   second gene, and so on. If the nested list/tuple has a ``None``
-   value, then the gene's initial value is selected randomly from the
-   range specified by the 2 parameters ``init_range_low`` and
-   ``init_range_high`` and its mutation value is selected randomly from
-   the range specified by the 2 parameters ``random_mutation_min_val``
-   and ``random_mutation_max_val``. ``gene_space`` is added in `PyGAD
-   2.5.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-5-0>`__.
-   Check the `Release History of PyGAD
-   2.5.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-5-0>`__
-   section of the documentation for more details. In `PyGAD
-   2.9.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-9-0>`__,
-   NumPy arrays can be assigned to the ``gene_space`` parameter. In
-   `PyGAD
-   2.11.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-11-0>`__,
-   the ``gene_space`` parameter itself or any of its elements can be
-   assigned to a dictionary to specify the lower and upper limits of the
-   genes. For example, ``{'low': 2, 'high': 4}`` means the minimum and
-   maximum values are 2 and 4, respectively. In `PyGAD
-   2.15.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-15-0>`__,
-   a new key called ``"step"`` is supported to specify the step of
-   moving from the start to the end of the range specified by the 2
-   existing keys ``"low"`` and ``"high"``.
+- ``gene_space=None``: It is used to specify the possible values for
+  each gene in case the user wants to restrict the gene values. It is
+  useful if the gene space is restricted to a certain range or to
+  discrete values. It accepts a ``list``, ``range``, or
+  ``numpy.ndarray``. When all genes have the same global space, specify
+  their values as a ``list``/``tuple``/``range``/``numpy.ndarray``. For
+  example, ``gene_space = [0.3, 5.2, -4, 8]`` restricts the gene values
+  to the 4 specified values. If each gene has its own space, then the
+  ``gene_space`` parameter can be nested like
+  ``[[0.4, -5], [0.5, -3.2, 8.2, -9], ...]`` where the first sublist
+  determines the values for the first gene, the second sublist for the
+  second gene, and so on. If the nested list/tuple has a ``None`` value,
+  then the gene's initial value is selected randomly from the range
+  specified by the 2 parameters ``init_range_low`` and
+  ``init_range_high`` and its mutation value is selected randomly from
+  the range specified by the 2 parameters ``random_mutation_min_val``
+  and ``random_mutation_max_val``. ``gene_space`` is added in `PyGAD
+  2.5.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-5-0>`__.
+  Check the `Release History of PyGAD
+  2.5.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-5-0>`__
+  section of the documentation for more details. In `PyGAD
+  2.9.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-9-0>`__,
+  NumPy arrays can be assigned to the ``gene_space`` parameter. In
+  `PyGAD
+  2.11.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-11-0>`__,
+  the ``gene_space`` parameter itself or any of its elements can be
+  assigned to a dictionary to specify the lower and upper limits of the
+  genes. For example, ``{'low': 2, 'high': 4}`` means the minimum and
+  maximum values are 2 and 4, respectively. In `PyGAD
+  2.15.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-15-0>`__,
+  a new key called ``"step"`` is supported to specify the step of moving
+  from the start to the end of the range specified by the 2 existing
+  keys ``"low"`` and ``"high"``.
 
--  ``on_start=None``: Accepts a function/method to be called only once
-   before the genetic algorithm starts its evolution. If function, then
-   it must accept a single parameter representing the instance of the
-   genetic algorithm. If method, then it must accept 2 parameters where
-   the second one refers to the method's object. Added in `PyGAD
-   2.6.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-6-0>`__.
+- ``on_start=None``: Accepts a function/method to be called only once
+  before the genetic algorithm starts its evolution. If function, then
+  it must accept a single parameter representing the instance of the
+  genetic algorithm. If method, then it must accept 2 parameters where
+  the second one refers to the method's object. Added in `PyGAD
+  2.6.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-6-0>`__.
 
--  ``on_fitness=None``: Accepts a function/method to be called after
-   calculating the fitness values of all solutions in the population. If
-   function, then it must accept 2 parameters: 1) a list of all
-   solutions' fitness values 2) the instance of the genetic algorithm.
-   If method, then it must accept 3 parameters where the third one
-   refers to the method's object. Added in `PyGAD
-   2.6.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-6-0>`__.
+- ``on_fitness=None``: Accepts a function/method to be called after
+  calculating the fitness values of all solutions in the population. If
+  function, then it must accept 2 parameters: 1) a list of all
+  solutions' fitness values 2) the instance of the genetic algorithm. If
+  method, then it must accept 3 parameters where the third one refers to
+  the method's object. Added in `PyGAD
+  2.6.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-6-0>`__.
 
--  ``on_parents=None``: Accepts a function/method to be called after
-   selecting the parents that mates. If function, then it must accept 2
-   parameters: 1) the selected parents 2) the instance of the genetic
-   algorithm If method, then it must accept 3 parameters where the third
-   one refers to the method's object. Added in `PyGAD
-   2.6.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-6-0>`__.
+- ``on_parents=None``: Accepts a function/method to be called after
+  selecting the parents that mates. If function, then it must accept 2
+  parameters: 1) the selected parents 2) the instance of the genetic
+  algorithm If method, then it must accept 3 parameters where the third
+  one refers to the method's object. Added in `PyGAD
+  2.6.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-6-0>`__.
 
--  ``on_crossover=None``: Accepts a function to be called each time the
-   crossover operation is applied. This function must accept 2
-   parameters: the first one represents the instance of the genetic
-   algorithm and the second one represents the offspring generated using
-   crossover. Added in `PyGAD
-   2.6.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-6-0>`__.
+- ``on_crossover=None``: Accepts a function to be called each time the
+  crossover operation is applied. This function must accept 2
+  parameters: the first one represents the instance of the genetic
+  algorithm and the second one represents the offspring generated using
+  crossover. Added in `PyGAD
+  2.6.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-6-0>`__.
 
--  ``on_mutation=None``: Accepts a function to be called each time the
-   mutation operation is applied. This function must accept 2
-   parameters: the first one represents the instance of the genetic
-   algorithm and the second one represents the offspring after applying
-   the mutation. Added in `PyGAD
-   2.6.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-6-0>`__.
+- ``on_mutation=None``: Accepts a function to be called each time the
+  mutation operation is applied. This function must accept 2 parameters:
+  the first one represents the instance of the genetic algorithm and the
+  second one represents the offspring after applying the mutation. Added
+  in `PyGAD
+  2.6.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-6-0>`__.
 
--  ``on_generation=None``: Accepts a function to be called after each
-   generation. This function must accept a single parameter representing
-   the instance of the genetic algorithm. If the function returned the
-   string ``stop``, then the ``run()`` method stops without completing
-   the other generations. Added in `PyGAD
-   2.6.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-6-0>`__.
+- ``on_generation=None``: Accepts a function to be called after each
+  generation. This function must accept a single parameter representing
+  the instance of the genetic algorithm. If the function returned the
+  string ``stop``, then the ``run()`` method stops without completing
+  the other generations. Added in `PyGAD
+  2.6.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-6-0>`__.
 
--  ``on_stop=None``: Accepts a function to be called only once exactly
-   before the genetic algorithm stops or when it completes all the
-   generations. This function must accept 2 parameters: the first one
-   represents the instance of the genetic algorithm and the second one
-   is a list of fitness values of the last population's solutions. Added
-   in `PyGAD
-   2.6.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-6-0>`__.
+- ``on_stop=None``: Accepts a function to be called only once exactly
+  before the genetic algorithm stops or when it completes all the
+  generations. This function must accept 2 parameters: the first one
+  represents the instance of the genetic algorithm and the second one is
+  a list of fitness values of the last population's solutions. Added in
+  `PyGAD
+  2.6.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-6-0>`__.
 
--  ``delay_after_gen=0.0``: It accepts a non-negative number specifying
-   the time in seconds to wait after a generation completes and before
-   going to the next generation. It defaults to ``0.0`` which means no
-   delay after the generation. Available in `PyGAD
-   2.4.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-4-0>`__
-   and higher.
+- ``save_best_solutions=False``: When ``True``, then the best solution
+  after each generation is saved into an attribute named
+  ``best_solutions``. If ``False`` (default), then no solutions are
+  saved and the ``best_solutions`` attribute will be empty. Supported in
+  `PyGAD
+  2.9.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-9-0>`__.
 
--  ``save_best_solutions=False``: When ``True``, then the best solution
-   after each generation is saved into an attribute named
-   ``best_solutions``. If ``False`` (default), then no solutions are
-   saved and the ``best_solutions`` attribute will be empty. Supported
-   in `PyGAD
-   2.9.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-9-0>`__.
+- ``save_solutions=False``: If ``True``, then all solutions in each
+  generation are appended into an attribute called ``solutions`` which
+  is NumPy array. Supported in `PyGAD
+  2.15.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-15-0>`__.
 
--  ``save_solutions=False``: If ``True``, then all solutions in each
-   generation are appended into an attribute called ``solutions`` which
-   is NumPy array. Supported in `PyGAD
-   2.15.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-15-0>`__.
+- ``suppress_warnings=False``: A bool parameter to control whether the
+  warning messages are printed or not. It defaults to ``False``.
 
--  ``suppress_warnings=False``: A bool parameter to control whether the
-   warning messages are printed or not. It defaults to ``False``.
+- ``allow_duplicate_genes=True``: Added in `PyGAD
+  2.13.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-13-0>`__.
+  If ``True``, then a solution/chromosome may have duplicate gene
+  values. If ``False``, then each gene will have a unique value in its
+  solution.
 
--  ``allow_duplicate_genes=True``: Added in `PyGAD
-   2.13.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-13-0>`__.
-   If ``True``, then a solution/chromosome may have duplicate gene
-   values. If ``False``, then each gene will have a unique value in its
-   solution.
+- ``stop_criteria=None``: Some criteria to stop the evolution. Added in
+  `PyGAD
+  2.15.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-15-0>`__.
+  Each criterion is passed as ``str`` which has a stop word. The current
+  2 supported words are ``reach`` and ``saturate``. ``reach`` stops the
+  ``run()`` method if the fitness value is equal to or greater than a
+  given fitness value. An example for ``reach`` is ``"reach_40"`` which
+  stops the evolution if the fitness is >= 40. ``saturate`` means stop
+  the evolution if the fitness saturates for a given number of
+  consecutive generations. An example for ``saturate`` is
+  ``"saturate_7"`` which means stop the ``run()`` method if the fitness
+  does not change for 7 consecutive generations.
 
--  ``stop_criteria=None``: Some criteria to stop the evolution. Added in
-   `PyGAD
-   2.15.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-15-0>`__.
-   Each criterion is passed as ``str`` which has a stop word. The
-   current 2 supported words are ``reach`` and ``saturate``. ``reach``
-   stops the ``run()`` method if the fitness value is equal to or
-   greater than a given fitness value. An example for ``reach`` is
-   ``"reach_40"`` which stops the evolution if the fitness is >= 40.
-   ``saturate`` means stop the evolution if the fitness saturates for a
-   given number of consecutive generations. An example for ``saturate``
-   is ``"saturate_7"`` which means stop the ``run()`` method if the
-   fitness does not change for 7 consecutive generations.
+- ``parallel_processing=None``: Added in `PyGAD
+  2.17.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-17-0>`__.
+  If ``None`` (Default), this means no parallel processing is applied.
+  It can accept a list/tuple of 2 elements [1) Can be either
+  ``'process'`` or ``'thread'`` to indicate whether processes or threads
+  are used, respectively., 2) The number of processes or threads to
+  use.]. For example, ``parallel_processing=['process', 10]`` applies
+  parallel processing with 10 processes. If a positive integer is
+  assigned, then it is used as the number of threads. For example,
+  ``parallel_processing=5`` uses 5 threads which is equivalent to
+  ``parallel_processing=["thread", 5]``. For more information, check the
+  `Parallel Processing in
+  PyGAD <https://pygad.readthedocs.io/en/latest/pygad_more.html#parallel-processing-in-pygad>`__
+  section.
 
--  ``parallel_processing=None``: Added in `PyGAD
-   2.17.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-17-0>`__.
-   If ``None`` (Default), this means no parallel processing is applied.
-   It can accept a list/tuple of 2 elements [1) Can be either
-   ``'process'`` or ``'thread'`` to indicate whether processes or
-   threads are used, respectively., 2) The number of processes or
-   threads to use.]. For example,
-   ``parallel_processing=['process', 10]`` applies parallel processing
-   with 10 processes. If a positive integer is assigned, then it is used
-   as the number of threads. For example, ``parallel_processing=5`` uses
-   5 threads which is equivalent to
-   ``parallel_processing=["thread", 5]``. For more information, check
-   the `Parallel Processing in
-   PyGAD <https://pygad.readthedocs.io/en/latest/pygad_more.html#parallel-processing-in-pygad>`__
-   section.
+- ``random_seed=None``: Added in `PyGAD
+  2.18.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-18-0>`__.
+  It defines the random seed to be used by the random function
+  generators (we use random functions in the NumPy and random modules).
+  This helps to reproduce the same results by setting the same random
+  seed (e.g. ``random_seed=2``). If given the value ``None``, then it
+  has no effect.
 
--  ``random_seed=None``: Added in `PyGAD
-   2.18.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-18-0>`__.
-   It defines the random seed to be used by the random function
-   generators (we use random functions in the NumPy and random modules).
-   This helps to reproduce the same results by setting the same random
-   seed (e.g. ``random_seed=2``). If given the value ``None``, then it
-   has no effect.
-
--  ``logger=None``: Accepts an instance of the ``logging.Logger`` class
-   to log the outputs. Any message is no longer printed using
-   ``print()`` but logged. If ``logger=None``, then a logger is created
-   that uses ``StreamHandler`` to logs the messages to the console.
-   Added in `PyGAD
-   3.0.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-3-0-0>`__.
-   Check the `Logging
-   Outputs <https://pygad.readthedocs.io/en/latest/pygad_more.html#logging-outputs>`__
-   for more information.
+- ``logger=None``: Accepts an instance of the ``logging.Logger`` class
+  to log the outputs. Any message is no longer printed using ``print()``
+  but logged. If ``logger=None``, then a logger is created that uses
+  ``StreamHandler`` to logs the messages to the console. Added in `PyGAD
+  3.0.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-3-0-0>`__.
+  Check the `Logging
+  Outputs <https://pygad.readthedocs.io/en/latest/pygad_more.html#logging-outputs>`__
+  for more information.
 
 The user doesn't have to specify all of such parameters while creating
 an instance of the GA class. A very important parameter you must care
@@ -448,25 +438,25 @@ parameter is not correct, an exception is thrown.
 Plotting Methods in ``pygad.GA`` Class
 --------------------------------------
 
--  ``plot_fitness()``: Shows how the fitness evolves by generation.
+- ``plot_fitness()``: Shows how the fitness evolves by generation.
 
--  ``plot_genes()``: Shows how the gene value changes for each
-   generation.
+- ``plot_genes()``: Shows how the gene value changes for each
+  generation.
 
--  ``plot_new_solution_rate()``: Shows the number of new solutions
-   explored in each solution.
+- ``plot_new_solution_rate()``: Shows the number of new solutions
+  explored in each solution.
 
 Class Attributes
 ----------------
 
--  ``supported_int_types``: A list of the supported types for the
-   integer numbers.
+- ``supported_int_types``: A list of the supported types for the integer
+  numbers.
 
--  ``supported_float_types``: A list of the supported types for the
-   floating-point numbers.
+- ``supported_float_types``: A list of the supported types for the
+  floating-point numbers.
 
--  ``supported_int_float_types``: A list of the supported types for all
-   numbers. It just concatenates the previous 2 lists.
+- ``supported_int_float_types``: A list of the supported types for all
+  numbers. It just concatenates the previous 2 lists.
 
 .. _other-instance-attributes--methods:
 
@@ -483,92 +473,92 @@ The next 2 subsections list such attributes and methods.
 Other Attributes
 ~~~~~~~~~~~~~~~~
 
--  ``generations_completed``: Holds the number of the last completed
-   generation.
+- ``generations_completed``: Holds the number of the last completed
+  generation.
 
--  ``population``: A NumPy array holding the initial population.
+- ``population``: A NumPy array holding the initial population.
 
--  ``valid_parameters``: Set to ``True`` when all the parameters passed
-   in the ``GA`` class constructor are valid.
+- ``valid_parameters``: Set to ``True`` when all the parameters passed
+  in the ``GA`` class constructor are valid.
 
--  ``run_completed``: Set to ``True`` only after the ``run()`` method
-   completes gracefully.
+- ``run_completed``: Set to ``True`` only after the ``run()`` method
+  completes gracefully.
 
--  ``pop_size``: The population size.
+- ``pop_size``: The population size.
 
--  ``best_solutions_fitness``: A list holding the fitness values of the
-   best solutions for all generations.
+- ``best_solutions_fitness``: A list holding the fitness values of the
+  best solutions for all generations.
 
--  ``best_solution_generation``: The generation number at which the best
-   fitness value is reached. It is only assigned the generation number
-   after the ``run()`` method completes. Otherwise, its value is -1.
+- ``best_solution_generation``: The generation number at which the best
+  fitness value is reached. It is only assigned the generation number
+  after the ``run()`` method completes. Otherwise, its value is -1.
 
--  ``best_solutions``: A NumPy array holding the best solution per each
-   generation. It only exists when the ``save_best_solutions`` parameter
-   in the ``pygad.GA`` class constructor is set to ``True``.
+- ``best_solutions``: A NumPy array holding the best solution per each
+  generation. It only exists when the ``save_best_solutions`` parameter
+  in the ``pygad.GA`` class constructor is set to ``True``.
 
--  ``last_generation_fitness``: The fitness values of the solutions in
-   the last generation. `Added in PyGAD
-   2.12.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-12-0>`__.
+- ``last_generation_fitness``: The fitness values of the solutions in
+  the last generation. `Added in PyGAD
+  2.12.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-12-0>`__.
 
--  ``previous_generation_fitness``: At the end of each generation, the
-   fitness of the most recent population is saved in the
-   ``last_generation_fitness`` attribute. The fitness of the population
-   exactly preceding this most recent population is saved in the
-   ``last_generation_fitness`` attribute. This
-   ``previous_generation_fitness`` attribute is used to fetch the
-   pre-calculated fitness instead of calling the fitness function for
-   already explored solutions. `Added in PyGAD
-   2.16.2 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-16-2>`__.
+- ``previous_generation_fitness``: At the end of each generation, the
+  fitness of the most recent population is saved in the
+  ``last_generation_fitness`` attribute. The fitness of the population
+  exactly preceding this most recent population is saved in the
+  ``last_generation_fitness`` attribute. This
+  ``previous_generation_fitness`` attribute is used to fetch the
+  pre-calculated fitness instead of calling the fitness function for
+  already explored solutions. `Added in PyGAD
+  2.16.2 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-16-2>`__.
 
--  ``last_generation_parents``: The parents selected from the last
-   generation. `Added in PyGAD
-   2.12.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-12-0>`__.
+- ``last_generation_parents``: The parents selected from the last
+  generation. `Added in PyGAD
+  2.12.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-12-0>`__.
 
--  ``last_generation_offspring_crossover``: The offspring generated
-   after applying the crossover in the last generation. `Added in PyGAD
-   2.12.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-12-0>`__.
+- ``last_generation_offspring_crossover``: The offspring generated after
+  applying the crossover in the last generation. `Added in PyGAD
+  2.12.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-12-0>`__.
 
--  ``last_generation_offspring_mutation``: The offspring generated after
-   applying the mutation in the last generation. `Added in PyGAD
-   2.12.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-12-0>`__.
+- ``last_generation_offspring_mutation``: The offspring generated after
+  applying the mutation in the last generation. `Added in PyGAD
+  2.12.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-12-0>`__.
 
--  ``gene_type_single``: A flag that is set to ``True`` if the
-   ``gene_type`` parameter is assigned to a single data type that is
-   applied to all genes. If ``gene_type`` is assigned a ``list``,
-   ``tuple``, or ``numpy.ndarray``, then the value of
-   ``gene_type_single`` will be ``False``. `Added in PyGAD
-   2.14.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-14-0>`__.
+- ``gene_type_single``: A flag that is set to ``True`` if the
+  ``gene_type`` parameter is assigned to a single data type that is
+  applied to all genes. If ``gene_type`` is assigned a ``list``,
+  ``tuple``, or ``numpy.ndarray``, then the value of
+  ``gene_type_single`` will be ``False``. `Added in PyGAD
+  2.14.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-14-0>`__.
 
--  ``last_generation_parents_indices``: This attribute holds the indices
-   of the selected parents in the last generation. Supported in `PyGAD
-   2.15.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-15-0>`__.
+- ``last_generation_parents_indices``: This attribute holds the indices
+  of the selected parents in the last generation. Supported in `PyGAD
+  2.15.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-15-0>`__.
 
--  ``last_generation_elitism``: This attribute holds the elitism of the
-   last generation. It is effective only if the ``keep_elitism``
-   parameter has a non-zero value. Supported in `PyGAD
-   2.18.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-18-0>`__.
+- ``last_generation_elitism``: This attribute holds the elitism of the
+  last generation. It is effective only if the ``keep_elitism``
+  parameter has a non-zero value. Supported in `PyGAD
+  2.18.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-18-0>`__.
 
--  ``last_generation_elitism_indices``: This attribute holds the indices
-   of the elitism of the last generation. It is effective only if the
-   ``keep_elitism`` parameter has a non-zero value. Supported in `PyGAD
-   2.19.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-19-0>`__.
+- ``last_generation_elitism_indices``: This attribute holds the indices
+  of the elitism of the last generation. It is effective only if the
+  ``keep_elitism`` parameter has a non-zero value. Supported in `PyGAD
+  2.19.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-19-0>`__.
 
--  ``logger``: This attribute holds the logger from the ``logging``
-   module. Supported in `PyGAD
-   3.0.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-3-0-0>`__.
+- ``logger``: This attribute holds the logger from the ``logging``
+  module. Supported in `PyGAD
+  3.0.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-3-0-0>`__.
 
--  ``gene_space_unpacked``: This is the unpacked version of the
-   ``gene_space`` parameter. For example, ``range(1, 5)`` is unpacked to
-   ``[1, 2, 3, 4]``. For an infinite range like
-   ``{'low': 2, 'high': 4}``, then it is unpacked to a limited number of
-   values (e.g. 100). Supported in `PyGAD
-   3.1.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-3-1-0>`__.
+- ``gene_space_unpacked``: This is the unpacked version of the
+  ``gene_space`` parameter. For example, ``range(1, 5)`` is unpacked to
+  ``[1, 2, 3, 4]``. For an infinite range like
+  ``{'low': 2, 'high': 4}``, then it is unpacked to a limited number of
+  values (e.g. 100). Supported in `PyGAD
+  3.1.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-3-1-0>`__.
 
--  ``pareto_fronts``: A new instance attribute named ``pareto_fronts``
-   added to the ``pygad.GA`` instances that holds the pareto fronts when
-   solving a multi-objective problem. Supported in `PyGAD
-   3.2.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-3-2-0>`__.
+- ``pareto_fronts``: A new instance attribute named ``pareto_fronts``
+  added to the ``pygad.GA`` instances that holds the pareto fronts when
+  solving a multi-objective problem. Supported in `PyGAD
+  3.2.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-3-2-0>`__.
 
 Note that the attributes with names starting with ``last_generation_``
 are updated after each generation.
@@ -576,55 +566,55 @@ are updated after each generation.
 Other Methods
 ~~~~~~~~~~~~~
 
--  ``cal_pop_fitness()``: A method that calculates the fitness values
-   for all solutions within the population by calling the function
-   passed to the ``fitness_func`` parameter for each solution.
+- ``cal_pop_fitness()``: A method that calculates the fitness values for
+  all solutions within the population by calling the function passed to
+  the ``fitness_func`` parameter for each solution.
 
--  ``crossover()``: Refers to the method that applies the crossover
-   operator based on the selected type of crossover in the
-   ``crossover_type`` property.
+- ``crossover()``: Refers to the method that applies the crossover
+  operator based on the selected type of crossover in the
+  ``crossover_type`` property.
 
--  ``mutation()``: Refers to the method that applies the mutation
-   operator based on the selected type of mutation in the
-   ``mutation_type`` property.
+- ``mutation()``: Refers to the method that applies the mutation
+  operator based on the selected type of mutation in the
+  ``mutation_type`` property.
 
--  ``select_parents()``: Refers to a method that selects the parents
-   based on the parent selection type specified in the
-   ``parent_selection_type`` attribute.
+- ``select_parents()``: Refers to a method that selects the parents
+  based on the parent selection type specified in the
+  ``parent_selection_type`` attribute.
 
--  ``adaptive_mutation_population_fitness()``: Returns the average
-   fitness value used in the adaptive mutation to filter the solutions.
+- ``adaptive_mutation_population_fitness()``: Returns the average
+  fitness value used in the adaptive mutation to filter the solutions.
 
--  ``summary()``: Prints a Keras-like summary of the PyGAD lifecycle.
-   This helps to have an overview of the architecture. Supported in
-   `PyGAD
-   2.19.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-19-0>`__.
-   Check the `Print Lifecycle
-   Summary <https://pygad.readthedocs.io/en/latest/pygad_more.html#print-lifecycle-summary>`__
-   section for more details and examples.
+- ``summary()``: Prints a Keras-like summary of the PyGAD lifecycle.
+  This helps to have an overview of the architecture. Supported in
+  `PyGAD
+  2.19.0 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-2-19-0>`__.
+  Check the `Print Lifecycle
+  Summary <https://pygad.readthedocs.io/en/latest/pygad_more.html#print-lifecycle-summary>`__
+  section for more details and examples.
 
--  4 methods with names starting with ``run_``. Their purpose is to keep
-   the main loop inside the ``run()`` method clean. The details inside
-   the loop are moved to 4 individual methods. Generally, any method
-   with a name starting with ``run_`` is meant to be called by PyGAD
-   from inside the ``run()`` method. Supported in `PyGAD
-   3.3.1 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-3-3-1>`__.
+- 4 methods with names starting with ``run_``. Their purpose is to keep
+  the main loop inside the ``run()`` method clean. The details inside
+  the loop are moved to 4 individual methods. Generally, any method with
+  a name starting with ``run_`` is meant to be called by PyGAD from
+  inside the ``run()`` method. Supported in `PyGAD
+  3.3.1 <https://pygad.readthedocs.io/en/latest/releases.html#pygad-3-3-1>`__.
 
-   1. ``run_select_parents(call_on_parents=True)``: Select the parents
-      and call the callable ``on_parents()`` if defined. If
-      ``call_on_parents`` is ``True``, then the callable
-      ``on_parents()`` is called. It must be ``False`` when the
-      ``run_select_parents()`` method is called to update the parents at
-      the end of the ``run()`` method.
+  1. ``run_select_parents(call_on_parents=True)``: Select the parents
+     and call the callable ``on_parents()`` if defined. If
+     ``call_on_parents`` is ``True``, then the callable ``on_parents()``
+     is called. It must be ``False`` when the ``run_select_parents()``
+     method is called to update the parents at the end of the ``run()``
+     method.
 
-   2. ``run_crossover()``: Apply crossover and call the callable
-      ``on_crossover()`` if defined.
+  2. ``run_crossover()``: Apply crossover and call the callable
+     ``on_crossover()`` if defined.
 
-   3. ``run_mutation()``: Apply mutation and call the callable
-      ``on_mutation()`` if defined.
+  3. ``run_mutation()``: Apply mutation and call the callable
+     ``on_mutation()`` if defined.
 
-   4. ``run_update_population()``: Update the ``population`` attribute
-      after completing the processes of crossover and mutation.
+  4. ``run_update_population()``: Update the ``population`` attribute
+     after completing the processes of crossover and mutation.
 
 The next sections discuss the methods available in the ``pygad.GA``
 class.
@@ -639,13 +629,13 @@ saved in the instance attribute named ``population``.
 
 Accepts the following parameters:
 
--  ``low``: The lower value of the random range from which the gene
-   values in the initial population are selected. It defaults to -4.
-   Available in PyGAD 1.0.20 and higher.
+- ``low``: The lower value of the random range from which the gene
+  values in the initial population are selected. It defaults to -4.
+  Available in PyGAD 1.0.20 and higher.
 
--  ``high``: The upper value of the random range from which the gene
-   values in the initial population are selected. It defaults to -4.
-   Available in PyGAD 1.0.20.
+- ``high``: The upper value of the random range from which the gene
+  values in the initial population are selected. It defaults to -4.
+  Available in PyGAD 1.0.20.
 
 This method assigns the values of the following 3 instance attributes:
 
@@ -731,20 +721,20 @@ the ``pygad.GA`` class constructor.
 
 After the generation completes, the following takes place:
 
--  The ``population`` attribute is updated by the new population.
+- The ``population`` attribute is updated by the new population.
 
--  The ``generations_completed`` attribute is assigned by the number of
-   the last completed generation.
+- The ``generations_completed`` attribute is assigned by the number of
+  the last completed generation.
 
--  If there is a callback function assigned to the ``on_generation``
-   attribute, then it will be called.
+- If there is a callback function assigned to the ``on_generation``
+  attribute, then it will be called.
 
 After the ``run()`` method completes, the following takes place:
 
--  The ``best_solution_generation`` is assigned the generation number at
-   which the best fitness value is reached.
+- The ``best_solution_generation`` is assigned the generation number at
+  which the best fitness value is reached.
 
--  The ``run_completed`` attribute is set to ``True``.
+- The ``run_completed`` attribute is set to ``True``.
 
 Parent Selection Methods
 ------------------------
@@ -754,10 +744,10 @@ module has several methods for selecting the parents that will mate to
 produce the offspring. All of such methods accept the same parameters
 which are:
 
--  ``fitness``: The fitness values of the solutions in the current
-   population.
+- ``fitness``: The fitness values of the solutions in the current
+  population.
 
--  ``num_parents``: The number of parents to be selected.
+- ``num_parents``: The number of parents to be selected.
 
 All of such methods return an array of the selected parents.
 
@@ -831,9 +821,9 @@ The ``Crossover`` class in the ``pygad.utils.crossover`` module supports
 several methods for applying crossover between the selected parents. All
 of these methods accept the same parameters which are:
 
--  ``parents``: The parents to mate for producing the offspring.
+- ``parents``: The parents to mate for producing the offspring.
 
--  ``offspring_size``: The size of the offspring to produce.
+- ``offspring_size``: The size of the offspring to produce.
 
 All of such methods return an array of the produced offspring.
 
@@ -878,7 +868,7 @@ The ``Mutation`` class in the ``pygad.utils.mutation`` module supports
 several methods for applying mutation. All of these methods accept the
 same parameter which is:
 
--  ``offspring``: The offspring to mutate.
+- ``offspring``: The offspring to mutate.
 
 All of such methods return an array of the mutated offspring.
 
@@ -942,19 +932,19 @@ algorithm.
 
 It accepts the following parameters:
 
--  ``pop_fitness=None``: An optional parameter that accepts a list of
-   the fitness values of the solutions in the population. If ``None``,
-   then the ``cal_pop_fitness()`` method is called to calculate the
-   fitness values of the population.
+- ``pop_fitness=None``: An optional parameter that accepts a list of the
+  fitness values of the solutions in the population. If ``None``, then
+  the ``cal_pop_fitness()`` method is called to calculate the fitness
+  values of the population.
 
 It returns the following:
 
--  ``best_solution``: Best solution in the current population.
+- ``best_solution``: Best solution in the current population.
 
--  ``best_solution_fitness``: Fitness value of the best solution.
+- ``best_solution_fitness``: Fitness value of the best solution.
 
--  ``best_match_idx``: Index of the best solution in the current
-   population.
+- ``best_match_idx``: Index of the best solution in the current
+  population.
 
 .. _plotfitness:
 
@@ -1008,8 +998,8 @@ Saves the genetic algorithm instance
 
 Accepts the following parameter:
 
--  ``filename``: Name of the file to save the instance. No extension is
-   needed.
+- ``filename``: Name of the file to save the instance. No extension is
+  needed.
 
 Functions in ``pygad``
 ======================
@@ -1029,8 +1019,8 @@ be called by the pygad module as follows: ``pygad.load(filename)``.
 
 Accepts the following parameter:
 
--  ``filename``: Name of the file holding the saved instance of the
-   genetic algorithm. No extension is needed.
+- ``filename``: Name of the file holding the saved instance of the
+  genetic algorithm. No extension is needed.
 
 Returns the genetic algorithm instance.
 
@@ -1076,16 +1066,16 @@ solution with a low value.
 The fitness function is where the user can decide whether the
 optimization problem is single-objective or multi-objective.
 
--  If the fitness function returns a numeric value, then the problem is
-   single-objective. The numeric data types supported by PyGAD are
-   listed in the ``supported_int_float_types`` variable of the
-   ``pygad.GA`` class.
+- If the fitness function returns a numeric value, then the problem is
+  single-objective. The numeric data types supported by PyGAD are listed
+  in the ``supported_int_float_types`` variable of the ``pygad.GA``
+  class.
 
--  If the fitness function returns a ``list``, ``tuple``, or
-   ``numpy.ndarray``, then the problem is multi-objective. Even if there
-   is only one element, the problem is still considered multi-objective.
-   Each element represents the fitness value of its corresponding
-   objective.
+- If the fitness function returns a ``list``, ``tuple``, or
+  ``numpy.ndarray``, then the problem is multi-objective. Even if there
+  is only one element, the problem is still considered multi-objective.
+  Each element represents the fitness value of its corresponding
+  objective.
 
 Using a user-defined fitness function allows the user to freely use
 PyGAD to solve any problem by passing the appropriate fitness
@@ -1268,8 +1258,7 @@ generations.
 
    ga_instance.plot_fitness()
 
-.. image:: https://user-images.githubusercontent.com/16560492/78830005-93111d00-79e7-11ea-9d8e-a8d8325a6101.png
-   :alt: 
+|image1|
 
 Information about the Best Solution
 -----------------------------------
@@ -1277,11 +1266,11 @@ Information about the Best Solution
 The following information about the best solution in the last population
 is returned using the ``best_solution()`` method.
 
--  Solution
+- Solution
 
--  Fitness value of the solution
+- Fitness value of the solution
 
--  Index of the solution within the population
+- Index of the solution within the population
 
 .. code:: python
 
@@ -1340,8 +1329,7 @@ instance of the ``pygad.GA`` class. Note that PyGAD stops when either
 all generations are completed or when the function passed to the
 ``on_generation`` parameter returns the string ``stop``.
 
-.. image:: https://user-images.githubusercontent.com/16560492/220486073-c5b6089d-81e4-44d9-a53c-385f479a7273.jpg
-   :alt: 
+|image2|
 
 The next code implements all the callback functions to trace the
 execution of the genetic algorithm. Each callback function prints its
@@ -1604,8 +1592,7 @@ This is the figure created by the ``plot_fitness()`` method. The fitness
 of the first objective has the green color. The blue color is used for
 the second objective fitness.
 
-.. image:: https://github.com/ahmedfgad/GeneticAlgorithmPython/assets/16560492/7896f8d8-01c5-4ff9-8d15-52191c309b63
-   :alt: 
+|image3|
 
 Reproducing Images
 ------------------
@@ -1620,29 +1607,29 @@ For more information about this project, read this tutorial titled
 Python <https://www.linkedin.com/pulse/reproducing-images-using-genetic-algorithm-python-ahmed-gad>`__
 available at these links:
 
--  `Heartbeat <https://heartbeat.fritz.ai/reproducing-images-using-a-genetic-algorithm-with-python-91fc701ff84>`__:
-   https://heartbeat.fritz.ai/reproducing-images-using-a-genetic-algorithm-with-python-91fc701ff84
+- `Heartbeat <https://heartbeat.fritz.ai/reproducing-images-using-a-genetic-algorithm-with-python-91fc701ff84>`__:
+  https://heartbeat.fritz.ai/reproducing-images-using-a-genetic-algorithm-with-python-91fc701ff84
 
--  `LinkedIn <https://www.linkedin.com/pulse/reproducing-images-using-genetic-algorithm-python-ahmed-gad>`__:
-   https://www.linkedin.com/pulse/reproducing-images-using-genetic-algorithm-python-ahmed-gad
+- `LinkedIn <https://www.linkedin.com/pulse/reproducing-images-using-genetic-algorithm-python-ahmed-gad>`__:
+  https://www.linkedin.com/pulse/reproducing-images-using-genetic-algorithm-python-ahmed-gad
 
 Project Steps
 ~~~~~~~~~~~~~
 
 The steps to follow in order to reproduce an image are as follows:
 
--  Read an image
+- Read an image
 
--  Prepare the fitness function
+- Prepare the fitness function
 
--  Create an instance of the pygad.GA class with the appropriate
-   parameters
+- Create an instance of the pygad.GA class with the appropriate
+  parameters
 
--  Run PyGAD
+- Run PyGAD
 
--  Plot results
+- Plot results
 
--  Calculate some statistics
+- Calculate some statistics
 
 The next sections discusses the code of each of these steps.
 
@@ -1663,8 +1650,7 @@ to the next code.
 
 Here is the read image.
 
-.. image:: https://user-images.githubusercontent.com/16560492/36948808-f0ac882e-1fe8-11e8-8d07-1307e3477fd0.jpg
-   :alt: 
+|image4|
 
 Based on the chromosome representation used in the example, the pixel
 values can be either in the 0-255, 0-1, or any other ranges.
@@ -1779,8 +1765,7 @@ generations can be viewed in a plot using the ``plot_fitness()`` method.
 
 Here is the plot after 20,000 generations.
 
-.. image:: https://user-images.githubusercontent.com/16560492/82232124-77762c00-992e-11ea-9fc6-14a1cd7a04ff.png
-   :alt: 
+|image5|
 
 Calculate Some Statistics
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1807,14 +1792,12 @@ Evolution by Generation
 
 The solution reached after the 20,000 generations is shown below.
 
-.. image:: https://user-images.githubusercontent.com/16560492/82232405-e0f63a80-992e-11ea-984f-b6ed76465bd1.png
-   :alt: 
+|image6|
 
 After more generations, the result can be enhanced like what shown
 below.
 
-.. image:: https://user-images.githubusercontent.com/16560492/82232345-cf149780-992e-11ea-8390-bf1a57a19de7.png
-   :alt: 
+|image7|
 
 The results can also be enhanced by changing the parameters passed to
 the constructor of the ``pygad.GA`` class.
@@ -1824,38 +1807,31 @@ Here is how the image is evolved from generation 0 to generation
 
 Generation 0
 
-.. image:: https://user-images.githubusercontent.com/16560492/36948589-b47276f0-1fe5-11e8-8efe-0cd1a225ea3a.png
-   :alt: 
+|image8|
 
 Generation 1,000
 
-.. image:: https://user-images.githubusercontent.com/16560492/36948823-16f490ee-1fe9-11e8-97db-3e8905ad5440.png
-   :alt: 
+|image9|
 
 Generation 2,500
 
-.. image:: https://user-images.githubusercontent.com/16560492/36948832-3f314b60-1fe9-11e8-8f4a-4d9a53b99f3d.png
-   :alt: 
+|image10|
 
 Generation 4,500
 
-.. image:: https://user-images.githubusercontent.com/16560492/36948837-53d1849a-1fe9-11e8-9b36-e9e9291e347b.png
-   :alt: 
+|image11|
 
 Generation 7,000
 
-.. image:: https://user-images.githubusercontent.com/16560492/36948852-66f1b176-1fe9-11e8-9f9b-460804e94004.png
-   :alt: 
+|image12|
 
 Generation 8,000
 
-.. image:: https://user-images.githubusercontent.com/16560492/36948865-7fbb5158-1fe9-11e8-8c04-8ac3c1f7b1b1.png
-   :alt: 
+|image13|
 
 Generation 20,000
 
-.. image:: https://user-images.githubusercontent.com/16560492/82232405-e0f63a80-992e-11ea-984f-b6ed76465bd1.png
-   :alt: 
+|image14|
 
 Clustering
 ----------
@@ -1886,3 +1862,18 @@ for how the genetic algorithm plays CoinTex:
 https://blog.paperspace.com/building-agent-for-cointex-using-genetic-algorithm.
 Check also this `YouTube video <https://youtu.be/Sp_0RGjaL-0>`__ showing
 the genetic algorithm while playing CoinTex.
+
+.. |image1| image:: https://user-images.githubusercontent.com/16560492/78830005-93111d00-79e7-11ea-9d8e-a8d8325a6101.png
+.. |image2| image:: https://user-images.githubusercontent.com/16560492/220486073-c5b6089d-81e4-44d9-a53c-385f479a7273.jpg
+.. |image3| image:: https://github.com/ahmedfgad/GeneticAlgorithmPython/assets/16560492/7896f8d8-01c5-4ff9-8d15-52191c309b63
+.. |image4| image:: https://user-images.githubusercontent.com/16560492/36948808-f0ac882e-1fe8-11e8-8d07-1307e3477fd0.jpg
+.. |image5| image:: https://user-images.githubusercontent.com/16560492/82232124-77762c00-992e-11ea-9fc6-14a1cd7a04ff.png
+.. |image6| image:: https://user-images.githubusercontent.com/16560492/82232405-e0f63a80-992e-11ea-984f-b6ed76465bd1.png
+.. |image7| image:: https://user-images.githubusercontent.com/16560492/82232345-cf149780-992e-11ea-8390-bf1a57a19de7.png
+.. |image8| image:: https://user-images.githubusercontent.com/16560492/36948589-b47276f0-1fe5-11e8-8efe-0cd1a225ea3a.png
+.. |image9| image:: https://user-images.githubusercontent.com/16560492/36948823-16f490ee-1fe9-11e8-97db-3e8905ad5440.png
+.. |image10| image:: https://user-images.githubusercontent.com/16560492/36948832-3f314b60-1fe9-11e8-8f4a-4d9a53b99f3d.png
+.. |image11| image:: https://user-images.githubusercontent.com/16560492/36948837-53d1849a-1fe9-11e8-9b36-e9e9291e347b.png
+.. |image12| image:: https://user-images.githubusercontent.com/16560492/36948852-66f1b176-1fe9-11e8-9f9b-460804e94004.png
+.. |image13| image:: https://user-images.githubusercontent.com/16560492/36948865-7fbb5158-1fe9-11e8-8c04-8ac3c1f7b1b1.png
+.. |image14| image:: https://user-images.githubusercontent.com/16560492/82232405-e0f63a80-992e-11ea-984f-b6ed76465bd1.png

--- a/docs/source/releases.rst
+++ b/docs/source/releases.rst
@@ -1,8 +1,7 @@
 Release History
 ===============
 
-.. image:: https://user-images.githubusercontent.com/16560492/101267295-c74c0180-375f-11eb-9ad0-f8e37bd796ce.png
-   :alt: 
+|image1|
 
 .. _pygad-1017:
 
@@ -1551,6 +1550,81 @@ Release Date 17 February 2024
    Methods <https://pygad.readthedocs.io/en/latest/pygad.html#other-methods>`__
    section for more information.
 
+.. _pygad-340:
+
+PyGAD 3.4.0
+-----------
+
+Release Date 07 January 2025
+
+1.  The ``delay_after_gen`` parameter is removed from the ``pygad.GA``
+    class constructor. As a result, it is no longer an attribute of the
+    ``pygad.GA`` class instances. To add a delay after each generation,
+    apply it inside the ``on_generation`` callback.
+    https://github.com/ahmedfgad/GeneticAlgorithmPython/issues/283
+
+2.  In the ``single_point_crossover()`` method of the
+    ``pygad.utils.crossover.Crossover`` class, all the random crossover
+    points are returned before the ``for`` loop. This is by calling the
+    ``numpy.random.randint()`` function only once before the loop to
+    generate all the K points (where K is the offspring size). This is
+    compared to calling the ``numpy.random.randint()`` function inside
+    the ``for`` loop K times, once for each individual offspring.
+
+3.  Bug fix in the ``examples/example_custom_operators.py`` script.
+    https://github.com/ahmedfgad/GeneticAlgorithmPython/pull/285
+
+4.  While making prediction using the ``pygad.torchga.predict()``
+    function, no gradients are calculated.
+
+5.  The ``gene_type`` parameter of the
+    ``pygad.helper.unique.Unique.unique_int_gene_from_range()`` method
+    accepts the type of the current gene only instead of the full
+    gene_type list.
+
+6.  Created a new method called ``unique_float_gene_from_range()``
+    inside the ``pygad.helper.unique.Unique`` class to find a unique
+    floating-point number from a range.
+
+7.  Fix a bug in the
+    ``pygad.helper.unique.Unique.unique_gene_by_space()`` method to
+    return the numeric value only instead of a NumPy array.
+
+8.  Refactoring the ``pygad/helper/unique.py`` script to remove
+    duplicate codes and reformatting the docstrings.
+
+9.  The plot_pareto_front_curve() method added to the
+    pygad.visualize.plot.Plot class to visualize the Pareto front for
+    multi-objective problems. It only supports 2 objectives.
+    https://github.com/ahmedfgad/GeneticAlgorithmPython/issues/279
+
+10. Fix a bug converting a nested NumPy array to a nested list.
+    https://github.com/ahmedfgad/GeneticAlgorithmPython/issues/300
+
+11. The ``Matplotlib`` library is only imported when a method inside the
+    ``pygad/visualize/plot.py`` script is used. This is more efficient
+    than using ``import matplotlib.pyplot`` at the module level as this
+    causes it to be imported when ``pygad`` is imported even when it is
+    not needed.
+    https://github.com/ahmedfgad/GeneticAlgorithmPython/issues/292
+
+12. Fix a bug when minus sign (-) is used inside the ``stop_criteria``
+    parameter (e.g. ``stop_criteria=["saturate_10", "reach_-0.5"]``).
+    https://github.com/ahmedfgad/GeneticAlgorithmPython/issues/296
+
+13. Make sure ``self.best_solutions`` is a list of lists inside the
+    ``cal_pop_fitness`` method.
+    https://github.com/ahmedfgad/GeneticAlgorithmPython/issues/293
+
+14. Fix a bug where the ``cal_pop_fitness()`` method was using the
+    ``previous_generation_fitness`` attribute to return the parents
+    fitness. This instance attribute was not using the fitness of the
+    latest population, instead the fitness of the population before the
+    last one. The issue is solved by updating the
+    ``previous_generation_fitness`` attribute to the latest population
+    fitness before the GA completes.
+    https://github.com/ahmedfgad/GeneticAlgorithmPython/issues/291
+
 PyGAD Projects at GitHub
 ========================
 
@@ -1721,11 +1795,11 @@ section for more contact details.
 
 Within your message, please send the following details:
 
--  Project title
+- Project title
 
--  Brief description
+- Brief description
 
--  Preferably, a link that directs the readers to your project
+- Preferably, a link that directs the readers to your project
 
 Tutorials about PyGAD
 =====================
@@ -1851,7 +1925,7 @@ discussion includes building Keras models using either the Sequential
 Model or the Functional API, building an initial population of Keras
 model parameters, creating an appropriate fitness function, and more.
 
-|image1|
+|image2|
 
 `Train PyTorch Models Using Genetic Algorithm with PyGAD <https://neptune.ai/blog/train-pytorch-models-using-genetic-algorithm-with-pygad>`__
 ---------------------------------------------------------------------------------------------------------------------------------------------
@@ -1871,7 +1945,7 @@ PyTorch models. It’s very easy to use, but there are a few tricky steps.
 So, in this tutorial, we’ll explore how to use PyGAD to train PyTorch
 models.
 
-|image2|
+|image3|
 
 `A Guide to Genetic ‘Learning’ Algorithms for Optimization <https://towardsdatascience.com/a-guide-to-genetic-learning-algorithms-for-optimization-e1067cdc77e7>`__
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -1896,7 +1970,7 @@ simple pour résoudre le OpenAI CartPole Jeu. Dans cet article, nous
 allons former un simple réseau de neurones pour résoudre le OpenAI
 CartPole . J'utiliserai PyTorch et PyGAD .
 
-|image3|
+|image4|
 
 Spanish
 -------
@@ -1914,7 +1988,7 @@ resolver el Juego OpenAI CartPole. En este articulo, entrenaremos una
 red neuronal simple para resolver el OpenAI CartPole . Usare PyTorch y
 PyGAD .
 
-|image4|
+|image5|
 
 Korean
 ------
@@ -1922,7 +1996,7 @@ Korean
 `[PyGAD] Python 에서 Genetic Algorithm 을 사용해보기 <https://data-newbie.tistory.com/m/685>`__
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-|image5|
+|image6|
 
 파이썬에서 genetic algorithm을 사용하는 패키지들을 다 사용해보진
 않았지만, 확장성이 있어보이고, 시도할 일이 있어서 살펴봤다.
@@ -1971,7 +2045,7 @@ Keras modellerini oluşturmayı, Keras model parametrelerinin ilk
 popülasyonunu oluşturmayı, uygun bir uygunluk işlevi oluşturmayı ve daha
 fazlasını içerir.
 
-|image6|
+|image7|
 
 Hungarian
 ---------
@@ -2003,7 +2077,7 @@ hálózatunk 386 állítható paraméterrel rendelkezik, ezért a DNS-ünk itt
 populációnk egy 10x386 elemű mátrix lesz. Ezt adjuk át az 51. sorban az
 initial_population paraméterben.
 
-|image7|
+|image8|
 
 Russian
 -------
@@ -2032,77 +2106,75 @@ PyGAD разрабатывали на Python 3.7.3. Зависимости вк�
 из изкейсов использования инструмента — оптимизация весов, которые
 удовлетворяют заданной функции.
 
-|image8|
+|image9|
 
 Research Papers using PyGAD
 ===========================
 
 A number of research papers used PyGAD and here are some of them:
 
--  Alberto Meola, Manuel Winkler, Sören Weinrich, Metaheuristic
-   optimization of data preparation and machine learning hyperparameters
-   for prediction of dynamic methane production, Bioresource Technology,
-   Volume 372, 2023, 128604, ISSN 0960-8524.
+- Alberto Meola, Manuel Winkler, Sören Weinrich, Metaheuristic
+  optimization of data preparation and machine learning hyperparameters
+  for prediction of dynamic methane production, Bioresource Technology,
+  Volume 372, 2023, 128604, ISSN 0960-8524.
 
--  Jaros, Marta, and Jiri Jaros. "Performance-Cost Optimization of
-   Moldable Scientific Workflows."
+- Jaros, Marta, and Jiri Jaros. "Performance-Cost Optimization of
+  Moldable Scientific Workflows."
 
--  Thorat, Divya. "Enhanced genetic algorithm to reduce makespan of
-   multiple jobs in map-reduce application on serverless platform".
-   Diss. Dublin, National College of Ireland, 2020.
+- Thorat, Divya. "Enhanced genetic algorithm to reduce makespan of
+  multiple jobs in map-reduce application on serverless platform". Diss.
+  Dublin, National College of Ireland, 2020.
 
--  Koch, Chris, and Edgar Dobriban. "AttenGen: Generating Live
-   Attenuated Vaccine Candidates using Machine Learning." (2021).
+- Koch, Chris, and Edgar Dobriban. "AttenGen: Generating Live Attenuated
+  Vaccine Candidates using Machine Learning." (2021).
 
--  Bhardwaj, Bhavya, et al. "Windfarm optimization using Nelder-Mead and
-   Particle Swarm optimization." *2021 7th International Conference on
-   Electrical Energy Systems (ICEES)*. IEEE, 2021.
+- Bhardwaj, Bhavya, et al. "Windfarm optimization using Nelder-Mead and
+  Particle Swarm optimization." *2021 7th International Conference on
+  Electrical Energy Systems (ICEES)*. IEEE, 2021.
 
--  Bernardo, Reginald Christian S. and J. Said. “Towards a
-   model-independent reconstruction approach for late-time Hubble data.”
-   (2021).
+- Bernardo, Reginald Christian S. and J. Said. “Towards a
+  model-independent reconstruction approach for late-time Hubble data.”
+  (2021).
 
--  Duong, Tri Dung, Qian Li, and Guandong Xu. "Prototype-based
-   Counterfactual Explanation for Causal Classification." *arXiv
-   preprint arXiv:2105.00703* (2021).
+- Duong, Tri Dung, Qian Li, and Guandong Xu. "Prototype-based
+  Counterfactual Explanation for Causal Classification." *arXiv preprint
+  arXiv:2105.00703* (2021).
 
--  Farrag, Tamer Ahmed, and Ehab E. Elattar. "Optimized Deep Stacked
-   Long Short-Term Memory Network for Long-Term Load Forecasting." *IEEE
-   Access* 9 (2021): 68511-68522.
+- Farrag, Tamer Ahmed, and Ehab E. Elattar. "Optimized Deep Stacked Long
+  Short-Term Memory Network for Long-Term Load Forecasting." *IEEE
+  Access* 9 (2021): 68511-68522.
 
--  Antunes, E. D. O., Caetano, M. F., Marotta, M. A., Araujo, A.,
-   Bondan, L., Meneguette, R. I., & Rocha Filho, G. P. (2021, August).
-   Soluções Otimizadas para o Problema de Localização de Máxima
-   Cobertura em Redes Militarizadas 4G/LTE. In *Anais do XXVI Workshop
-   de Gerência e Operação de Redes e Serviços* (pp. 152-165). SBC.
+- Antunes, E. D. O., Caetano, M. F., Marotta, M. A., Araujo, A., Bondan,
+  L., Meneguette, R. I., & Rocha Filho, G. P. (2021, August). Soluções
+  Otimizadas para o Problema de Localização de Máxima Cobertura em Redes
+  Militarizadas 4G/LTE. In *Anais do XXVI Workshop de Gerência e
+  Operação de Redes e Serviços* (pp. 152-165). SBC.
 
--  M. Yani, F. Ardilla, A. A. Saputra and N. Kubota, "Gradient-Free Deep
-   Q-Networks Reinforcement learning: Benchmark and Evaluation," *2021
-   IEEE Symposium Series on Computational Intelligence (SSCI)*, 2021,
-   pp. 1-5, doi: 10.1109/SSCI50451.2021.9659941.
+- M. Yani, F. Ardilla, A. A. Saputra and N. Kubota, "Gradient-Free Deep
+  Q-Networks Reinforcement learning: Benchmark and Evaluation," *2021
+  IEEE Symposium Series on Computational Intelligence (SSCI)*, 2021, pp.
+  1-5, doi: 10.1109/SSCI50451.2021.9659941.
 
--  Yani, Mohamad, and Naoyuki Kubota. "Deep Convolutional Networks with
-   Genetic Algorithm for Reinforcement Learning Problem."
+- Yani, Mohamad, and Naoyuki Kubota. "Deep Convolutional Networks with
+  Genetic Algorithm for Reinforcement Learning Problem."
 
--  Mahendra, Muhammad Ihza, and Isman Kurniawan. "Optimizing
-   Convolutional Neural Network by Using Genetic Algorithm for COVID-19
-   Detection in Chest X-Ray Image." *2021 International Conference on
-   Data Science and Its Applications (ICoDSA)*. IEEE, 2021.
+- Mahendra, Muhammad Ihza, and Isman Kurniawan. "Optimizing
+  Convolutional Neural Network by Using Genetic Algorithm for COVID-19
+  Detection in Chest X-Ray Image." *2021 International Conference on
+  Data Science and Its Applications (ICoDSA)*. IEEE, 2021.
 
--  Glibota, Vjeko. *Umjeravanje mikroskopskog prometnog modela primjenom
-   genetskog algoritma*. Diss. University of Zagreb. Faculty of
-   Transport and Traffic Sciences. Division of Intelligent Transport
-   Systems and Logistics. Department of Intelligent Transport Systems,
-   2021.
+- Glibota, Vjeko. *Umjeravanje mikroskopskog prometnog modela primjenom
+  genetskog algoritma*. Diss. University of Zagreb. Faculty of Transport
+  and Traffic Sciences. Division of Intelligent Transport Systems and
+  Logistics. Department of Intelligent Transport Systems, 2021.
 
--  Zhu, Mingda. *Genetic Algorithm-based Parameter Identification for
-   Ship Manoeuvring Model under Wind Disturbance*. MS thesis. NTNU,
-   2021.
+- Zhu, Mingda. *Genetic Algorithm-based Parameter Identification for
+  Ship Manoeuvring Model under Wind Disturbance*. MS thesis. NTNU, 2021.
 
--  Abdalrahman, Ahmed, and Weihua Zhuang. "Dynamic pricing for
-   differentiated pev charging services using deep reinforcement
-   learning." *IEEE Transactions on Intelligent Transportation Systems*
-   (2020).
+- Abdalrahman, Ahmed, and Weihua Zhuang. "Dynamic pricing for
+  differentiated pev charging services using deep reinforcement
+  learning." *IEEE Transactions on Intelligent Transportation Systems*
+  (2020).
 
 More Links
 ==========
@@ -2125,19 +2197,19 @@ titled `Genetic Algorithm Implementation in
 Python <https://www.linkedin.com/pulse/genetic-algorithm-implementation-python-ahmed-gad>`__
 available at these links:
 
--  `LinkedIn <https://www.linkedin.com/pulse/genetic-algorithm-implementation-python-ahmed-gad>`__
+- `LinkedIn <https://www.linkedin.com/pulse/genetic-algorithm-implementation-python-ahmed-gad>`__
 
--  `Towards Data
-   Science <https://towardsdatascience.com/genetic-algorithm-implementation-in-python-5ab67bb124a6>`__
+- `Towards Data
+  Science <https://towardsdatascience.com/genetic-algorithm-implementation-in-python-5ab67bb124a6>`__
 
--  `KDnuggets <https://www.kdnuggets.com/2018/07/genetic-algorithm-implementation-python.html>`__
+- `KDnuggets <https://www.kdnuggets.com/2018/07/genetic-algorithm-implementation-python.html>`__
 
 `This
 tutorial <https://www.linkedin.com/pulse/genetic-algorithm-implementation-python-ahmed-gad>`__
 is prepared based on a previous version of the project but it still a
 good resource to start with coding the genetic algorithm.
 
-|image9|
+|image10|
 
 Tutorial: Introduction to Genetic Algorithm
 -------------------------------------------
@@ -2147,14 +2219,14 @@ Get started with the genetic algorithm by reading the tutorial titled
 Algorithm <https://www.linkedin.com/pulse/introduction-optimization-genetic-algorithm-ahmed-gad>`__
 which is available at these links:
 
--  `LinkedIn <https://www.linkedin.com/pulse/introduction-optimization-genetic-algorithm-ahmed-gad>`__
+- `LinkedIn <https://www.linkedin.com/pulse/introduction-optimization-genetic-algorithm-ahmed-gad>`__
 
--  `Towards Data
-   Science <https://www.kdnuggets.com/2018/03/introduction-optimization-with-genetic-algorithm.html>`__
+- `Towards Data
+  Science <https://www.kdnuggets.com/2018/03/introduction-optimization-with-genetic-algorithm.html>`__
 
--  `KDnuggets <https://towardsdatascience.com/introduction-to-optimization-with-genetic-algorithm-2f5001d9964b>`__
+- `KDnuggets <https://towardsdatascience.com/introduction-to-optimization-with-genetic-algorithm-2f5001d9964b>`__
 
-|image10|
+|image11|
 
 Tutorial: Build Neural Networks in Python
 -----------------------------------------
@@ -2165,14 +2237,14 @@ Classification of the Fruits360 Image
 Dataset <https://www.linkedin.com/pulse/artificial-neural-network-implementation-using-numpy-fruits360-gad>`__
 available at these links:
 
--  `LinkedIn <https://www.linkedin.com/pulse/artificial-neural-network-implementation-using-numpy-fruits360-gad>`__
+- `LinkedIn <https://www.linkedin.com/pulse/artificial-neural-network-implementation-using-numpy-fruits360-gad>`__
 
--  `Towards Data
-   Science <https://towardsdatascience.com/artificial-neural-network-implementation-using-numpy-and-classification-of-the-fruits360-image-3c56affa4491>`__
+- `Towards Data
+  Science <https://towardsdatascience.com/artificial-neural-network-implementation-using-numpy-and-classification-of-the-fruits360-image-3c56affa4491>`__
 
--  `KDnuggets <https://www.kdnuggets.com/2019/02/artificial-neural-network-implementation-using-numpy-and-image-classification.html>`__
+- `KDnuggets <https://www.kdnuggets.com/2019/02/artificial-neural-network-implementation-using-numpy-and-image-classification.html>`__
 
-|image11|
+|image12|
 
 Tutorial: Optimize Neural Networks with Genetic Algorithm
 ---------------------------------------------------------
@@ -2183,14 +2255,14 @@ Genetic Algorithm with
 Python <https://www.linkedin.com/pulse/artificial-neural-networks-optimization-using-genetic-ahmed-gad>`__
 available at these links:
 
--  `LinkedIn <https://www.linkedin.com/pulse/artificial-neural-networks-optimization-using-genetic-ahmed-gad>`__
+- `LinkedIn <https://www.linkedin.com/pulse/artificial-neural-networks-optimization-using-genetic-ahmed-gad>`__
 
--  `Towards Data
-   Science <https://towardsdatascience.com/artificial-neural-networks-optimization-using-genetic-algorithm-with-python-1fe8ed17733e>`__
+- `Towards Data
+  Science <https://towardsdatascience.com/artificial-neural-networks-optimization-using-genetic-algorithm-with-python-1fe8ed17733e>`__
 
--  `KDnuggets <https://www.kdnuggets.com/2019/03/artificial-neural-networks-optimization-genetic-algorithm-python.html>`__
+- `KDnuggets <https://www.kdnuggets.com/2019/03/artificial-neural-networks-optimization-genetic-algorithm-python.html>`__
 
-|image12|
+|image13|
 
 Tutorial: Building CNN in Python
 --------------------------------
@@ -2200,21 +2272,21 @@ titled `Building Convolutional Neural Network using NumPy from
 Scratch <https://www.linkedin.com/pulse/building-convolutional-neural-network-using-numpy-from-ahmed-gad>`__
 available at these links:
 
--  `LinkedIn <https://www.linkedin.com/pulse/building-convolutional-neural-network-using-numpy-from-ahmed-gad>`__
+- `LinkedIn <https://www.linkedin.com/pulse/building-convolutional-neural-network-using-numpy-from-ahmed-gad>`__
 
--  `Towards Data
-   Science <https://towardsdatascience.com/building-convolutional-neural-network-using-numpy-from-scratch-b30aac50e50a>`__
+- `Towards Data
+  Science <https://towardsdatascience.com/building-convolutional-neural-network-using-numpy-from-scratch-b30aac50e50a>`__
 
--  `KDnuggets <https://www.kdnuggets.com/2018/04/building-convolutional-neural-network-numpy-scratch.html>`__
+- `KDnuggets <https://www.kdnuggets.com/2018/04/building-convolutional-neural-network-numpy-scratch.html>`__
 
--  `Chinese Translation <http://m.aliyun.com/yunqi/articles/585741>`__
+- `Chinese Translation <http://m.aliyun.com/yunqi/articles/585741>`__
 
 `This
 tutorial <https://www.linkedin.com/pulse/building-convolutional-neural-network-using-numpy-from-ahmed-gad>`__)
 is prepared based on a previous version of the project but it still a
 good resource to start with coding CNNs.
 
-|image13|
+|image14|
 
 Tutorial: Derivation of CNN from FCNN
 -------------------------------------
@@ -2224,14 +2296,14 @@ Get started with the genetic algorithm by reading the tutorial titled
 Step-By-Step <https://www.linkedin.com/pulse/derivation-convolutional-neural-network-from-fully-connected-gad>`__
 which is available at these links:
 
--  `LinkedIn <https://www.linkedin.com/pulse/derivation-convolutional-neural-network-from-fully-connected-gad>`__
+- `LinkedIn <https://www.linkedin.com/pulse/derivation-convolutional-neural-network-from-fully-connected-gad>`__
 
--  `Towards Data
-   Science <https://towardsdatascience.com/derivation-of-convolutional-neural-network-from-fully-connected-network-step-by-step-b42ebafa5275>`__
+- `Towards Data
+  Science <https://towardsdatascience.com/derivation-of-convolutional-neural-network-from-fully-connected-network-step-by-step-b42ebafa5275>`__
 
--  `KDnuggets <https://www.kdnuggets.com/2018/04/derivation-convolutional-neural-network-fully-connected-step-by-step.html>`__
+- `KDnuggets <https://www.kdnuggets.com/2018/04/derivation-convolutional-neural-network-fully-connected-step-by-step.html>`__
 
-|image14|
+|image15|
 
 Book: Practical Computer Vision Applications Using Deep Learning with CNNs
 --------------------------------------------------------------------------
@@ -2244,69 +2316,70 @@ learning, genetic algorithm, and more.
 
 Find the book at these links:
 
--  `Amazon <https://www.amazon.com/Practical-Computer-Vision-Applications-Learning/dp/1484241665>`__
+- `Amazon <https://www.amazon.com/Practical-Computer-Vision-Applications-Learning/dp/1484241665>`__
 
--  `Springer <https://link.springer.com/book/10.1007/978-1-4842-4167-7>`__
+- `Springer <https://link.springer.com/book/10.1007/978-1-4842-4167-7>`__
 
--  `Apress <https://www.apress.com/gp/book/9781484241660>`__
+- `Apress <https://www.apress.com/gp/book/9781484241660>`__
 
--  `O'Reilly <https://www.oreilly.com/library/view/practical-computer-vision/9781484241677>`__
+- `O'Reilly <https://www.oreilly.com/library/view/practical-computer-vision/9781484241677>`__
 
--  `Google Books <https://books.google.com.eg/books?id=xLd9DwAAQBAJ>`__
+- `Google Books <https://books.google.com.eg/books?id=xLd9DwAAQBAJ>`__
 
-.. image:: https://user-images.githubusercontent.com/16560492/78830077-ae7c2800-79e7-11ea-980b-53b6bd879eeb.jpg
-   :alt: 
+|image16|
 
 Contact Us
 ==========
 
--  E-mail: ahmed.f.gad@gmail.com
+- E-mail: ahmed.f.gad@gmail.com
 
--  `LinkedIn <https://www.linkedin.com/in/ahmedfgad>`__
+- `LinkedIn <https://www.linkedin.com/in/ahmedfgad>`__
 
--  `Amazon Author Page <https://amazon.com/author/ahmedgad>`__
+- `Amazon Author Page <https://amazon.com/author/ahmedgad>`__
 
--  `Heartbeat <https://heartbeat.fritz.ai/@ahmedfgad>`__
+- `Heartbeat <https://heartbeat.fritz.ai/@ahmedfgad>`__
 
--  `Paperspace <https://blog.paperspace.com/author/ahmed>`__
+- `Paperspace <https://blog.paperspace.com/author/ahmed>`__
 
--  `KDnuggets <https://kdnuggets.com/author/ahmed-gad>`__
+- `KDnuggets <https://kdnuggets.com/author/ahmed-gad>`__
 
--  `TowardsDataScience <https://towardsdatascience.com/@ahmedfgad>`__
+- `TowardsDataScience <https://towardsdatascience.com/@ahmedfgad>`__
 
--  `GitHub <https://github.com/ahmedfgad>`__
+- `GitHub <https://github.com/ahmedfgad>`__
 
-.. image:: https://user-images.githubusercontent.com/16560492/101267295-c74c0180-375f-11eb-9ad0-f8e37bd796ce.png
-   :alt: 
+|image17|
 
 Thank you for using
 `PyGAD <https://github.com/ahmedfgad/GeneticAlgorithmPython>`__ :)
 
-.. |image1| image:: https://user-images.githubusercontent.com/16560492/111009628-2b372500-8362-11eb-90cf-01b47d831624.png
+.. |image1| image:: https://user-images.githubusercontent.com/16560492/101267295-c74c0180-375f-11eb-9ad0-f8e37bd796ce.png
+.. |image2| image:: https://user-images.githubusercontent.com/16560492/111009628-2b372500-8362-11eb-90cf-01b47d831624.png
    :target: https://blog.paperspace.com/train-keras-models-using-genetic-algorithm-with-pygad
-.. |image2| image:: https://user-images.githubusercontent.com/16560492/111009678-5457b580-8362-11eb-899a-39e2f96984df.png
+.. |image3| image:: https://user-images.githubusercontent.com/16560492/111009678-5457b580-8362-11eb-899a-39e2f96984df.png
    :target: https://neptune.ai/blog/train-pytorch-models-using-genetic-algorithm-with-pygad
-.. |image3| image:: https://user-images.githubusercontent.com/16560492/111009275-3178d180-8361-11eb-9e86-7fb1519acde7.png
+.. |image4| image:: https://user-images.githubusercontent.com/16560492/111009275-3178d180-8361-11eb-9e86-7fb1519acde7.png
    :target: https://www.hebergementwebs.com/nouvelles/comment-les-algorithmes-genetiques-peuvent-rivaliser-avec-la-descente-de-gradient-et-le-backprop
-.. |image4| image:: https://user-images.githubusercontent.com/16560492/111009257-232ab580-8361-11eb-99a5-7226efbc3065.png
+.. |image5| image:: https://user-images.githubusercontent.com/16560492/111009257-232ab580-8361-11eb-99a5-7226efbc3065.png
    :target: https://www.hebergementwebs.com/noticias/como-los-algoritmos-geneticos-pueden-competir-con-el-descenso-de-gradiente-y-el-backprop
-.. |image5| image:: https://user-images.githubusercontent.com/16560492/108586306-85bd0280-731b-11eb-874c-7ac4ce1326cd.jpg
+.. |image6| image:: https://user-images.githubusercontent.com/16560492/108586306-85bd0280-731b-11eb-874c-7ac4ce1326cd.jpg
    :target: https://data-newbie.tistory.com/m/685
-.. |image6| image:: https://user-images.githubusercontent.com/16560492/108586601-85be0200-731d-11eb-98a4-161c75a1f099.jpg
+.. |image7| image:: https://user-images.githubusercontent.com/16560492/108586601-85be0200-731d-11eb-98a4-161c75a1f099.jpg
    :target: https://erencan34.medium.com/pygad-ile-genetik-algoritmay%C4%B1-kullanarak-keras-modelleri-nas%C4%B1l-e%C4%9Fitilir-cf92639a478c
-.. |image7| image:: https://user-images.githubusercontent.com/16560492/101267295-c74c0180-375f-11eb-9ad0-f8e37bd796ce.png
-   :target: https://thebojda.medium.com/tensorflow-alapoz%C3%B3-10-24f7767d4a2c
 .. |image8| image:: https://user-images.githubusercontent.com/16560492/101267295-c74c0180-375f-11eb-9ad0-f8e37bd796ce.png
+   :target: https://thebojda.medium.com/tensorflow-alapoz%C3%B3-10-24f7767d4a2c
+.. |image9| image:: https://user-images.githubusercontent.com/16560492/101267295-c74c0180-375f-11eb-9ad0-f8e37bd796ce.png
    :target: https://neurohive.io/ru/frameworki/pygad-biblioteka-dlya-implementacii-geneticheskogo-algoritma
-.. |image9| image:: https://user-images.githubusercontent.com/16560492/78830052-a3c19300-79e7-11ea-8b9b-4b343ea4049c.png
+.. |image10| image:: https://user-images.githubusercontent.com/16560492/78830052-a3c19300-79e7-11ea-8b9b-4b343ea4049c.png
    :target: https://www.linkedin.com/pulse/genetic-algorithm-implementation-python-ahmed-gad
-.. |image10| image:: https://user-images.githubusercontent.com/16560492/82078259-26252d00-96e1-11ea-9a02-52a99e1054b9.jpg
+.. |image11| image:: https://user-images.githubusercontent.com/16560492/82078259-26252d00-96e1-11ea-9a02-52a99e1054b9.jpg
    :target: https://www.linkedin.com/pulse/introduction-optimization-genetic-algorithm-ahmed-gad
-.. |image11| image:: https://user-images.githubusercontent.com/16560492/82078281-30472b80-96e1-11ea-8017-6a1f4383d602.jpg
+.. |image12| image:: https://user-images.githubusercontent.com/16560492/82078281-30472b80-96e1-11ea-8017-6a1f4383d602.jpg
    :target: https://www.linkedin.com/pulse/artificial-neural-network-implementation-using-numpy-fruits360-gad
-.. |image12| image:: https://user-images.githubusercontent.com/16560492/82078300-376e3980-96e1-11ea-821c-aa6b8ceb44d4.jpg
+.. |image13| image:: https://user-images.githubusercontent.com/16560492/82078300-376e3980-96e1-11ea-821c-aa6b8ceb44d4.jpg
    :target: https://www.linkedin.com/pulse/artificial-neural-networks-optimization-using-genetic-ahmed-gad
-.. |image13| image:: https://user-images.githubusercontent.com/16560492/82431022-6c3a1200-9a8e-11ea-8f1b-b055196d76e3.png
+.. |image14| image:: https://user-images.githubusercontent.com/16560492/82431022-6c3a1200-9a8e-11ea-8f1b-b055196d76e3.png
    :target: https://www.linkedin.com/pulse/building-convolutional-neural-network-using-numpy-from-ahmed-gad
-.. |image14| image:: https://user-images.githubusercontent.com/16560492/82431369-db176b00-9a8e-11ea-99bd-e845192873fc.png
+.. |image15| image:: https://user-images.githubusercontent.com/16560492/82431369-db176b00-9a8e-11ea-99bd-e845192873fc.png
    :target: https://www.linkedin.com/pulse/derivation-convolutional-neural-network-from-fully-connected-gad
+.. |image16| image:: https://user-images.githubusercontent.com/16560492/78830077-ae7c2800-79e7-11ea-980b-53b6bd879eeb.jpg
+.. |image17| image:: https://user-images.githubusercontent.com/16560492/101267295-c74c0180-375f-11eb-9ad0-f8e37bd796ce.png

--- a/examples/example_multi_objective.py
+++ b/examples/example_multi_objective.py
@@ -54,6 +54,7 @@ ga_instance = pygad.GA(num_generations=num_generations,
 ga_instance.run()
 
 ga_instance.plot_fitness(label=['Obj 1', 'Obj 2'])
+ga_instance.plot_pareto_front_curve()
 
 # Returning the details of the best solution.
 solution, solution_fitness, solution_idx = ga_instance.best_solution(ga_instance.last_generation_fitness)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pygad"
-version = "3.3.1"
+version = "3.4.0"
 description = "PyGAD: A Python Library for Building the Genetic Algorithm and Training Machine Learning Algoithms (Keras & PyTorch)."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(  
     name="pygad",  
-    version="3.3.1",  
+    version="3.4.0",  
     author="Ahmed Fawzy Gad",
     install_requires=["numpy", "matplotlib", "cloudpickle",],
     author_email="ahmed.f.gad@gmail.com",  


### PR DESCRIPTION
1. The `delay_after_gen` parameter is removed from the `pygad.GA` class constructor. As a result, it is no longer an attribute of the `pygad.GA` class instances. To add a delay after each generation, apply it inside the `on_generation` callback. https://github.com/ahmedfgad/GeneticAlgorithmPython/issues/283
2. In the `single_point_crossover()` method of the `pygad.utils.crossover.Crossover` class, all the random crossover points are returned before the `for` loop. This is by calling the `numpy.random.randint()` function only once before the loop to generate all the K points (where K is the offspring size). This is compared to calling the `numpy.random.randint()` function inside the `for` loop K times, once for each individual offspring.
3. Bug fix in the `examples/example_custom_operators.py` script. https://github.com/ahmedfgad/GeneticAlgorithmPython/pull/285
4. While making prediction using the `pygad.torchga.predict()` function, no gradients are calculated.
5. The `gene_type` parameter of the `pygad.helper.unique.Unique.unique_int_gene_from_range()` method accepts the type of the current gene only instead of the full gene_type list.
6. Created a new method called `unique_float_gene_from_range()` inside the `pygad.helper.unique.Unique` class to find a unique floating-point number from a range.
7. Fix a bug in the `pygad.helper.unique.Unique.unique_gene_by_space()` method to return the numeric value only instead of a NumPy array.
8. Refactoring the `pygad/helper/unique.py` script to remove duplicate codes and reformatting the docstrings.
9. The plot_pareto_front_curve() method added to the pygad.visualize.plot.Plot class to visualize the Pareto front for multi-objective problems. It only supports 2 objectives. https://github.com/ahmedfgad/GeneticAlgorithmPython/issues/279
10. Fix a bug converting a nested NumPy array to a nested list. https://github.com/ahmedfgad/GeneticAlgorithmPython/issues/300
11. The `Matplotlib` library is only imported when a method inside the `pygad/visualize/plot.py` script is used. This is more efficient than using `import matplotlib.pyplot` at the module level as this causes it to be imported when `pygad` is imported even when it is not needed. https://github.com/ahmedfgad/GeneticAlgorithmPython/issues/292
12. Fix a bug when minus sign (-) is used inside the `stop_criteria` parameter (e.g. `stop_criteria=["saturate_10", "reach_-0.5"]`). https://github.com/ahmedfgad/GeneticAlgorithmPython/issues/296
13. Make sure `self.best_solutions` is a list of lists inside the `cal_pop_fitness` method. https://github.com/ahmedfgad/GeneticAlgorithmPython/issues/293
14. Fix a bug where the `cal_pop_fitness()` method was using the `previous_generation_fitness` attribute to return the parents fitness. This instance attribute was not using the fitness of the latest population, instead the fitness of the population before the last one. The issue is solved by updating the `previous_generation_fitness` attribute to the latest population fitness before the GA completes. https://github.com/ahmedfgad/GeneticAlgorithmPython/issues/291